### PR TITLE
chapi2: Cleanup/Extend Windows iSCSI API support

### DIFF
--- a/windows/iscsidsc/add_iscsi_send_target_portal.go
+++ b/windows/iscsidsc/add_iscsi_send_target_portal.go
@@ -1,0 +1,37 @@
+// (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+
+// +build windows
+
+// Package iscsidsc wraps the Windows iSCSI Discovery Library API
+package iscsidsc
+
+import (
+	"syscall"
+	"unsafe"
+
+	log "github.rtplab.nimblestorage.com/dcs/common/logger"
+)
+
+// AddIScsiSendTargetPortal - Go wrapped Win32 API - AddIScsiSendTargetPortalW()
+// https://docs.microsoft.com/en-us/windows/win32/api/iscsidsc/nf-iscsidsc-addiscsisendtargetportalw
+func AddIScsiSendTargetPortal(initiatorInstance string, initiatorPortNumber uint32, address string) (err error) {
+	log.Infof(">>>>> AddIScsiSendTargetportal, initiatorInstance=%v, initiatorPortNumber=%v, address=%v", initiatorInstance, initiatorPortNumber, address)
+	defer log.Infoln("<<<<< AddIScsiSendTargetPortal")
+
+	// Convert initiatorInstance into a raw equivalent so that we can send it to the iSCSI API
+	initiatorNameUTF16 := syscall.StringToUTF16(initiatorInstance)
+
+	// Allocate and initialize an ISCSI_TARGET_PORTAL_RAW object
+	targetPortal := ISCSI_TARGET_PORTAL{Address: address, Socket: 3260}
+	targetPortalRaw := iscsiTargetPortalToRaw(&targetPortal)
+
+	// Call the Win32 AddIScsiSendTargetPortalW API
+	iscsiErr, _, _ := procAddIScsiSendTargetPortalW.Call(uintptr(unsafe.Pointer(&initiatorNameUTF16[0])), uintptr(initiatorPortNumber), uintptr(0), uintptr(0), uintptr(unsafe.Pointer(targetPortalRaw)))
+	if iscsiErr != ERROR_SUCCESS {
+		// If an unexpected error occurs, initialize error object and log failure
+		err = syscall.Errno(iscsiErr)
+		log.Errorln(logIscsiFailure, err.Error())
+	}
+
+	return err
+}

--- a/windows/iscsidsc/get_iscsi_session_list.go
+++ b/windows/iscsidsc/get_iscsi_session_list.go
@@ -32,7 +32,7 @@ func GetIscsiSessionList() (iscsiSessions []*ISCSI_SESSION_INFO, err error) {
 		var bufferSizeNeeded, sessionCount uint32
 		iscsiErr, _, _ = procGetIScsiSessionListW.Call(uintptr(unsafe.Pointer(&bufferSizeNeeded)), uintptr(unsafe.Pointer(&sessionCount)), uintptr(0))
 
-		if (iscsiErr == uintptr(syscall.ERROR_INSUFFICIENT_BUFFER)) && (sessionCount > 0) {
+		if (iscsiErr == uintptr(syscall.ERROR_INSUFFICIENT_BUFFER)) && ((sessionCount > 0) || (bufferSizeNeeded > 0)) {
 
 			// NWT-3303.  Additional safety measure we'll add to deal with NWT-3303 is to bump
 			// up the size of the buffer we'll allocate.  That way, in the unlikely event the

--- a/windows/iscsidsc/iscsidsc.go
+++ b/windows/iscsidsc/iscsidsc.go
@@ -6,6 +6,7 @@
 package iscsidsc
 
 import (
+	"math"
 	"syscall"
 	"unsafe"
 
@@ -19,6 +20,8 @@ const (
 
 // iSCSI definitions
 const (
+	ISCSI_ALL_INITIATOR_PORTS    = uint32(math.MaxUint32)
+	ISCSI_ANY_INITIATOR_PORT     = uint32(math.MaxUint32)
 	MAX_ISCSI_ALIAS_LEN          = 255
 	MAX_ISCSI_HBANAME_LEN        = 256
 	MAX_ISCSI_NAME_LEN           = 223
@@ -211,6 +214,7 @@ const (
 // Lazy load the iSCSI DLL APIs
 var (
 	iscsidsc                             = windows.NewLazySystemDLL("iscsidsc.dll")
+	procAddIScsiSendTargetPortalW        = iscsidsc.NewProc("AddIScsiSendTargetPortalW")
 	procGetDevicesForIScsiSessionW       = iscsidsc.NewProc("GetDevicesForIScsiSessionW")
 	procGetIScsiInitiatorNodeNameW       = iscsidsc.NewProc("GetIScsiInitiatorNodeNameW")
 	procGetIScsiSessionListW             = iscsidsc.NewProc("GetIScsiSessionListW")

--- a/windows/iscsidsc/login_iscsi_target.go
+++ b/windows/iscsidsc/login_iscsi_target.go
@@ -146,8 +146,8 @@ func loginIScsiTarget(targetName string, initiatorInstance string, initiatorPort
 		uintptr(0), // KeySize is not supported
 		uintptr(0), // key is not supported
 		uintptr(isPersistentInt),
-		uintptr(unsafe.Pointer(&uniqueSessionID)),
-		uintptr(unsafe.Pointer(&uniqueConnectionID)))
+		uintptr(unsafe.Pointer(uniqueSessionID)),
+		uintptr(unsafe.Pointer(uniqueConnectionID)))
 
 	if iscsiErr != ERROR_SUCCESS {
 		// If an unexpected error occurs, initialize error object and log failure


### PR DESCRIPTION
* Problem:
  * Need to add iSCSI discovery API support to add a send target portal
  * Need to fix a few minor issues
* Implementation:
  * NOTE:  Entry/exit logging still using Info vs Trace; will resolve in all packages in a future update
  * add_iscsi_send_target_portal.go
    * New file that wraps the AddIScsiSendTargetPortalW() iSCSI API
  * get_iscsi_session_list.go
    * When no sessions are connected, the iSCSI API would still return ERROR_INSUFFICIENT_BUFFER with a sessionCount of 0.  To make sure we get a clean non-failing call to this API, we've added a check for bufferSizeNeeded > 0.  That way if the API indicates it wants a larger buffer, we'll allocate the buffer and then call the API a second time.
  * iscsidsc.go
    * Added definitions for iSCSI API ISCSI_ALL_INITIATOR_PORTS and ISCSI_ANY_INITIATOR_PORT constants
    * Added enumeration of AddIScsiSendTargetPortalW API pointer
  * login_iscsi_target.go
    * Fixed a bug where we were passing a pointer to the uniqueSessionID and uniqueConnectionID variables to the LoginIScsiTargetW() iSCSI API.  These variables are already pointers (allocated by new).  We were incorrectly passing a pointer to a pointer.
* Testing:
  * Tested API changes on a Windows host
  * Verified Linux and Windows builds are still successful
* Reviewers:
  * @skrishna, @sbyadarahalli
* Bug: N/A