### PR TITLE
chapi2: Enhance iSCSI package

### DIFF
--- a/chapi2/iscsi/iscsi.go
+++ b/chapi2/iscsi/iscsi.go
@@ -36,8 +36,10 @@ func (plugin *IscsiPlugin) GetDiscoveredTargets() ([]*model.IscsiTarget, error) 
 func (plugin *IscsiPlugin) GetAllLoggedInTargets() ([]*model.IscsiTarget, error) {
 	return nil, nil
 }
-func (plugin *IscsiPlugin) GetTargetPortals(targetName string) ([]string, error) {
-	return nil, nil
+func (plugin *IscsiPlugin) GetTargetPortals(targetName string, ipv4Only bool) ([]*model.TargetPortal, error) {
+	log.Infof(">>> GetTargetPortals, targetName=%v, ipv4Only=%v", targetName, ipv4Only)
+	defer log.Infoln("<<< GetTargetPortals")
+	return plugin.getTargetPortals(targetName, ipv4Only)
 }
 func (plugin *IscsiPlugin) GetSessionProperties(targetName string, sessionId string) (map[string]string, error) {
 	return nil, nil

--- a/chapi2/iscsi/iscsi_linux.go
+++ b/chapi2/iscsi/iscsi_linux.go
@@ -33,7 +33,7 @@ func getIscsiInitiators() (init *model.Initiator, err error) {
 		return nil, cerrors.NewChapiError(cerrors.NotFound, errorMessageEmptyIqnFound)
 	}
 	log.Infof("got iscsi initiator name as %s", initiators[0])
-	init = &model.Initiator{AccessProtocol: "iscsi", Init: initiators}
+	init = &model.Initiator{AccessProtocol: model.AccessProtocolIscsi, Init: initiators}
 	return init, err
 }
 
@@ -48,4 +48,10 @@ func getTargetScope(targetName string) (targetScope string, err error) {
 func rescanIscsiTarget(lunID string) error {
 	// TODO
 	return nil
+}
+
+// getTargetPortals enumerates the target portals for the given iSCSI target
+func (plugin *IscsiPlugin) getTargetPortals(targetName string, ipv4Only bool) ([]*model.TargetPortal, error) {
+	// TODO
+	return nil, nil
 }

--- a/chapi2/model/types.go
+++ b/chapi2/model/types.go
@@ -22,7 +22,18 @@ package model
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 const (
-	TargetScopeGroup  = "group"  // TargetScopeGroup Group Scoped Target (GST)
+	// AccessProtocolIscsi - iSCSI volume
+	AccessProtocolIscsi = "iscsi"
+
+	// AccessProtocolFC - Fibre Channel volume
+	AccessProtocolFC = "fc"
+)
+
+const (
+	// TargetScopeGroup - Multi-LUN capable target, Group Scoped Target (GST)
+	TargetScopeGroup = "group" // Group Scoped Target (GST)
+
+	// TargetScopeVolume - Single LUN capable target, Volume Scoped Target (VST)
 	TargetScopeVolume = "volume" // Volume Scoped Target (VST)
 )
 
@@ -73,16 +84,17 @@ type Initiator struct {
 
 // IscsiTarget struct
 type IscsiTarget struct {
-	Name          string         `json:"name,omitempty"`           // Target iSCSI iqn
-	TargetPortals []TargetPortal `json:"target_portals,omitempty"` // Target portals
-	TargetScope   string         `json:"target_scope,omitempty"`   // GST="group", VST="volume" or empty if unknown scope or FC
+	Name          string          `json:"name,omitempty"`           // Target iSCSI iqn
+	TargetPortals []*TargetPortal `json:"target_portals,omitempty"` // Target portals
+	TargetScope   string          `json:"target_scope,omitempty"`   // GST="group", VST="volume" or empty if unknown scope or FC
 }
 
 // TargetPortal provides information for a single iSCSI target portal (i.e. Data IP)
 type TargetPortal struct {
-	Address string `json:"address,omitempty"` // Target port IP address
-	Port    string `json:"port,omitempty"`    // Target port socket
-	Tag     string `json:"tag,omitempty"`     // Target port tag
+	Address string               `json:"address,omitempty"` // Target port IP address
+	Port    string               `json:"port,omitempty"`    // Target port socket
+	Tag     string               `json:"tag,omitempty"`     // Target port tag
+	Private *TargetPortalPrivate `json:"-"`                 // Private TargetPortal properties used internally by CHAPI
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/chapi2/model/types_linux.go
+++ b/chapi2/model/types_linux.go
@@ -24,6 +24,10 @@ type Path struct {
 type NetworkPrivate struct {
 }
 
+// TargetPortalPrivate provides model.TargetPortal platform specific private data
+type TargetPortalPrivate struct {
+}
+
 // DevicePrivate provides model.Device platform specific private data
 type DevicePrivate struct {
 	Paths []Path `json:"-"` // Physical path details (used internally by CHAPI server)

--- a/chapi2/model/types_windows.go
+++ b/chapi2/model/types_windows.go
@@ -3,6 +3,7 @@
 package model
 
 import (
+	"github.com/hpe-storage/common-host-libs/windows/iscsidsc"
 	"github.com/hpe-storage/common-host-libs/windows/wmi"
 )
 
@@ -15,6 +16,11 @@ type KeyFileInfo struct {
 type NetworkPrivate struct {
 	InitiatorInstance   string // WMI MSiSCSI_PortalInfoClass->InstanceName
 	InitiatorPortNumber uint32 // WMI MSiSCSI_PortalInfoClass->ISCSI_PortalInfo->Index
+}
+
+// TargetPortalPrivate provides model.TargetPortal platform specific private data
+type TargetPortalPrivate struct {
+	WindowsTargetPortal *iscsidsc.ISCSI_TARGET_PORTAL `json:"-"` // Windows iSCSI target portal object
 }
 
 // DevicePrivate provides model.Device platform specific private data

--- a/windows/iscsidsc/add_iscsi_send_target_portal.go
+++ b/windows/iscsidsc/add_iscsi_send_target_portal.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	log "github.rtplab.nimblestorage.com/dcs/common/logger"
+	log "github.com/hpe-storage/common-host-libs/logger"
 )
 
 // AddIScsiSendTargetPortal - Go wrapped Win32 API - AddIScsiSendTargetPortalW()


### PR DESCRIPTION
* Problem:
  * Enhance CHAPI2 iSCSI package
* Implementation:
  * chapi2 model package
    * Added const strings for AccessProtocolIscsi and AccessProtocolFC.
    * Changed IscsiTarget.TargetPortals from an array of TargetPortal objects to an array of pointers to TargetPortal objects.  This makes the usage more consistent with other CHAPI2 objects, such as the Host struct.
    * Added a "TargetPortalPrivate" property to the "TargetPortal" object.  This allows for platform specific extensions to the TargetPortal object.
    * Defined TargetPortalPrivate object for Windows which contains an iscsidsc.ISCSI_TARGET_PORTAL object.
    * Defined an empty TargetPortalPrivate object for Linux.
  * chapi2 multipath package
    * Changed IscsiTarget.TargetPortals from an array of TargetPortal objects to an array of pointers to TargetPortal objects.
    * Removed getTargetPortals from Windows module; moved to iscsi package
  * chapi2 iscsi package
    * Added support for GetTargetPortals() method
    * For Windows, implemented getTargetPortals()
    * For Linux, added getTargetPortals() stub
    * For both Windows and Linux, replaced "iscsi" string with model.AccessProtocolIscsi
  * add_iscsi_send_target_portal.go
    * Fixed import path to reflect new hpe-storage repository
* Testing:
  * Successfully built on Linux and Windows
  * Successfully executed endpoints on Windows
* Reviewers:
  * @shivamerla @suneeth51 
* Bug: N/A