### PR TITLE
CSI Driver (Clone Volume): Handle clone creation when size greater than source size

### DIFF
--- a/storageprovider/csp/container_storage_provider.go
+++ b/storageprovider/csp/container_storage_provider.go
@@ -243,8 +243,8 @@ func (provider *ContainerStorageProvider) CreateVolume(name, description string,
 
 // CloneVolume clones a volume on the CSP
 // nolint : gocyclo
-func (provider *ContainerStorageProvider) CloneVolume(name, description, sourceID, snapshotID string, opts map[string]interface{}) (*model.Volume, error) {
-	log.Tracef(">>>>> CloneVolume with name: %v, description: %v, sourceID: %v, snapshotID %v", name, description, sourceID, snapshotID)
+func (provider *ContainerStorageProvider) CloneVolume(name, description, sourceID, snapshotID string, size int64, opts map[string]interface{}) (*model.Volume, error) {
+	log.Tracef(">>>>> CloneVolume with name: %v, description: %v, sourceID: %v, snapshotID %v, size: %d", name, description, sourceID, snapshotID, size)
 	defer log.Trace("<<<<< CloneVolume")
 
 	// Check for empty name
@@ -271,7 +271,7 @@ func (provider *ContainerStorageProvider) CloneVolume(name, description, sourceI
 			return nil, errors.New("Could not find snapshot with id " + snapshotID)
 		}
 	} else if snapshotID == "" {
-		log.Trace("Creating snapshot for new clone")
+		log.Tracef("Creating snapshot for new clone from source volume %s", sourceID)
 
 		snapshotName := snapshotPrefix + time.Now().Format(time.RFC3339)
 		snapshot, err = provider.CreateSnapshot(snapshotName, snapshotName, sourceID, nil)
@@ -285,6 +285,12 @@ func (provider *ContainerStorageProvider) CloneVolume(name, description, sourceI
 		}
 	}
 
+	// Check for valid resize value. Must be equal or higher than the snapshot size.
+	if size < snapshot.Size {
+		errMsg := fmt.Sprintf("Clone size %v requested is smaller than the snapshot size %v", size, snapshot.Size)
+		return nil, fmt.Errorf("Could not create new volume clone, err: %s", errMsg)
+	}
+
 	dataWrapper := &DataWrapper{
 		Data: &model.Volume{},
 	}
@@ -293,6 +299,7 @@ func (provider *ContainerStorageProvider) CloneVolume(name, description, sourceI
 	volume := &model.Volume{
 		Name:        name,
 		Description: description,
+		Size:        size,
 		BaseSnapID:  snapshot.ID,
 		Clone:       true,
 		Config:      opts,

--- a/storageprovider/csp/container_storage_provider_test.go
+++ b/storageprovider/csp/container_storage_provider_test.go
@@ -16,6 +16,7 @@ const (
 	volumeSize   = 1024 * 1024 * 1024
 	snapshotName = "testCspSnapshot"
 	cloneName    = "testCspVolClone"
+	cloneSize    = 2 * 1024 * 1024 * 1024
 )
 
 var (
@@ -71,7 +72,7 @@ func _TestPluginSuite(t *testing.T) {
 	assert.True(t, len(volumes) != 0)
 
 	// CloneVolume without a source snapshot ID will indirectly test snapshot creation
-	clone := createClone(t, provider, volume.ID, "")
+	clone := createClone(t, provider, volume.ID, "", cloneSize)
 
 	// Get the auto created snapshot
 	snapshot, err := provider.GetSnapshot(clone.BaseSnapID)
@@ -94,7 +95,7 @@ func _TestPluginSuite(t *testing.T) {
 	assert.Equal(t, snapshot.VolumeID, volume.ID)
 
 	// Clone from that snapshot
-	clone = createClone(t, provider, "", snapshot.ID)
+	clone = createClone(t, provider, "", snapshot.ID, cloneSize)
 
 	// Delete the clone
 	deleteVolume(t, provider, clone)
@@ -123,14 +124,15 @@ func realCsp(t *testing.T) *ContainerStorageProvider {
 	return provider
 }
 
-func createClone(t *testing.T, provider *ContainerStorageProvider, sourceVolumeID, snapshotID string) *model.Volume {
+func createClone(t *testing.T, provider *ContainerStorageProvider, sourceVolumeID, snapshotID string, size int64) *model.Volume {
 	config := make(map[string]interface{})
 	config["test"] = "test"
-	clone, err := provider.CloneVolume(cloneName, cloneName, sourceVolumeID, snapshotID, config)
+	clone, err := provider.CloneVolume(cloneName, cloneName, sourceVolumeID, snapshotID, size, config)
 	if err != nil {
 		t.Fatal("Failed to clone volume")
 	}
 	assert.Equal(t, clone.Name, cloneName)
+	assert.Equal(t, clone.Size, cloneSize)
 
 	snapshot, err := provider.GetSnapshot(clone.BaseSnapID)
 	if err != nil {

--- a/storageprovider/fake/fake_storage_provider.go
+++ b/storageprovider/fake/fake_storage_provider.go
@@ -53,7 +53,7 @@ func (provider *StorageProvider) CreateVolume(name, description string, size int
 }
 
 // CloneVolume returns a fake volume
-func (provider *StorageProvider) CloneVolume(name, description, sourceID, snapshotID string, opts map[string]interface{}) (*model.Volume, error) {
+func (provider *StorageProvider) CloneVolume(name, description, sourceID, snapshotID string, size int64, opts map[string]interface{}) (*model.Volume, error) {
 	if _, ok := provider.volumes[name]; ok {
 		return nil, fmt.Errorf("Volume named %s already exists", name)
 	}
@@ -82,6 +82,7 @@ func (provider *StorageProvider) CloneVolume(name, description, sourceID, snapsh
 	fakeClone := model.Volume{
 		ID:         name,
 		Name:       name,
+		Size:       size,
 		BaseSnapID: snapshot.ID,
 	}
 	provider.volumes[name] = fakeClone

--- a/storageprovider/storage_provider.go
+++ b/storageprovider/storage_provider.go
@@ -30,7 +30,7 @@ type StorageProvider interface {
 	GetVolumeByName(name string) (*model.Volume, error)
 	GetVolumes() ([]*model.Volume, error)
 	CreateVolume(name, description string, size int64, opts map[string]interface{}) (*model.Volume, error)
-	CloneVolume(name, description, sourceID, snapshotID string, opts map[string]interface{}) (*model.Volume, error)
+	CloneVolume(name, description, sourceID, snapshotID string, size int64, opts map[string]interface{}) (*model.Volume, error)
 	DeleteVolume(id string) error
 	PublishVolume(id, hostID, accessProtocol string) (*model.PublishInfo, error) // Idempotent
 	UnpublishVolume(id, hostID string) error                                     // Idempotent


### PR DESCRIPTION
- Volume clone creation with size >= snapshot size is allowed, else error will be returned.
- CSP handles the resize in CloneVolume() endpoint.