### PR TITLE
chapi2:  Transition log.Info* to log.Trace*

### DIFF
--- a/chapi2/chapi.go
+++ b/chapi2/chapi.go
@@ -105,7 +105,7 @@ func NewRouter() *mux.Router {
 		//         {                                                      {
 		//              "access_protocol":  "iscsi",                           "access_protocol":  "iscsi",
 		//              "initiator":  [                                        "initiator":  [
-		//                  "iqn.1994-05.com.redhat:32b8e991e082"                  "iqn.1991-05.com.microsoft:hitdev-win011.mikeb.local"
+		//                  "iqn.1994-05.com.redhat:32b8e991e082"                  "iqn.1991-05.com.microsoft:hitdev-win011.local"
 		//             ]                                                      ]
 		//         }                                                      }
 		//     ]                                                      ]

--- a/chapi2/driver/driver.go
+++ b/chapi2/driver/driver.go
@@ -99,8 +99,8 @@ type ChapiServer struct {
 
 // GetHostInfo returns host name, domain, and network interfaces
 func (driver *ChapiServer) GetHostInfo() (*model.Host, error) {
-	log.Info(">>>>> GetHostInfo called")
-	defer log.Info("<<<<< GetHostInfo")
+	log.Trace(">>>>> GetHostInfo called")
+	defer log.Trace("<<<<< GetHostInfo")
 	hostPlugin := host.NewHostPlugin()
 
 	id, err := hostPlugin.GetUuid()
@@ -127,8 +127,8 @@ func (driver *ChapiServer) GetHostInfo() (*model.Host, error) {
 
 // GetHostNetworks reports the networks on this host
 func (driver *ChapiServer) GetHostNetworks() ([]*model.Network, error) {
-	log.Info(">>>>> GetHostNetworks called")
-	defer log.Info("<<<<< GetHostNetworks")
+	log.Trace(">>>>> GetHostNetworks called")
+	defer log.Trace("<<<<< GetHostNetworks")
 	hostPlugin := host.NewHostPlugin()
 
 	networks, err := hostPlugin.GetNetworks()
@@ -143,8 +143,8 @@ func (driver *ChapiServer) GetHostNetworks() ([]*model.Network, error) {
 
 // GetHostInitiators reports the initiators on this host
 func (driver *ChapiServer) GetHostInitiators() ([]*model.Initiator, error) {
-	log.Info(">>>>> GetHostInitiators called")
-	defer log.Info("<<<<< GetHostInitiators")
+	log.Trace(">>>>> GetHostInitiators called")
+	defer log.Trace("<<<<< GetHostInitiators")
 	//var inits Initiators
 	var inits []*model.Initiator
 
@@ -153,7 +153,7 @@ func (driver *ChapiServer) GetHostInitiators() ([]*model.Initiator, error) {
 
 	iscsiInits, err := iscsiPlugin.GetIscsiInitiators()
 	if err != nil {
-		log.Info("Error getting iscsiInitiator: ", err)
+		log.Trace("Error getting iscsiInitiator: ", err)
 	}
 
 	// fetch fc initiator details
@@ -161,7 +161,7 @@ func (driver *ChapiServer) GetHostInitiators() ([]*model.Initiator, error) {
 
 	fcInits, err := fcPlugin.GetFcInitiators()
 	if err != nil {
-		log.Info("Error getting FcInitiator: ", err)
+		log.Trace("Error getting FcInitiator: ", err)
 	}
 	if fcInits != nil {
 		inits = append(inits, fcInits)
@@ -174,7 +174,7 @@ func (driver *ChapiServer) GetHostInitiators() ([]*model.Initiator, error) {
 		return nil, cerrors.NewChapiError(cerrors.NotFound, errorMessageNoInitiatorsFound)
 	}
 
-	log.Info("initiators ", inits)
+	log.Trace("initiators ", inits)
 	return inits, nil
 }
 
@@ -185,8 +185,8 @@ func (driver *ChapiServer) GetHostInitiators() ([]*model.Initiator, error) {
 // GetDevices enumerates all the Nimble volumes with basic details.
 // If serialNumber is non-empty then only specified device is returned
 func (driver *ChapiServer) GetDevices(serialNumber string) ([]*model.Device, error) {
-	log.Info(">>>>> GetDevices called")
-	defer log.Info("<<<<< GetDevices")
+	log.Trace(">>>>> GetDevices called")
+	defer log.Trace("<<<<< GetDevices")
 	multipathPlugin := multipath.NewMultipathPlugin()
 
 	// Enumerate all the Nimble volumes on this host (basic details only)
@@ -206,8 +206,8 @@ func (driver *ChapiServer) GetDevices(serialNumber string) ([]*model.Device, err
 // GetAllDeviceDetails enumerates all the Nimble volumes with detailed information.
 // If serialNumber is non-empty then only specified device is returned
 func (driver *ChapiServer) GetAllDeviceDetails(serialNumber string) ([]*model.Device, error) {
-	log.Infof(">>>>> GetAllDeviceDetails called, serialNumber=%v", serialNumber)
-	defer log.Info("<<<<< GetAllDeviceDetails")
+	log.Tracef(">>>>> GetAllDeviceDetails called, serialNumber=%v", serialNumber)
+	defer log.Trace("<<<<< GetAllDeviceDetails")
 	multipathPlugin := multipath.NewMultipathPlugin()
 
 	// Enumerate all the Nimble volumes on this host (full details)
@@ -226,8 +226,8 @@ func (driver *ChapiServer) GetAllDeviceDetails(serialNumber string) ([]*model.De
 
 // GetPartitionInfo reports the partitions on the provided device
 func (driver *ChapiServer) GetPartitionInfo(serialNumber string) ([]*model.DevicePartition, error) {
-	log.Infof(">>>>> GetPartitionInfo called, serialNumber=%v", serialNumber)
-	defer log.Info("<<<<< GetPartitionInfo")
+	log.Tracef(">>>>> GetPartitionInfo called, serialNumber=%v", serialNumber)
+	defer log.Trace("<<<<< GetPartitionInfo")
 	multipathPlugin := multipath.NewMultipathPlugin()
 
 	// Enumerate all the Nimble volume's partition
@@ -246,8 +246,8 @@ func (driver *ChapiServer) GetPartitionInfo(serialNumber string) ([]*model.Devic
 
 // CreateDevice will attach device on this host based on the details provided
 func (driver *ChapiServer) CreateDevice(publishInfo model.PublishInfo) (*model.Device, error) {
-	log.Infof(">>>>> CreateDevice called, publishInfo=%v", publishInfo)
-	defer log.Info("<<<<< CreateDevice")
+	log.Tracef(">>>>> CreateDevice called, publishInfo=%v", publishInfo)
+	defer log.Trace("<<<<< CreateDevice")
 
 	// Invalid request if no device access object provided
 	if (publishInfo.BlockDev == nil) && (publishInfo.VirtualDev == nil) {
@@ -277,16 +277,16 @@ func (driver *ChapiServer) CreateDevice(publishInfo model.PublishInfo) (*model.D
 
 // DeleteDevice will delete the given device from the host
 func (driver *ChapiServer) DeleteDevice(serialNumber string) error {
-	log.Infof(">>>>> DeleteDevice called, serialNumber=%v", serialNumber)
-	defer log.Info("<<<<< DeleteDevice")
+	log.Tracef(">>>>> DeleteDevice called, serialNumber=%v", serialNumber)
+	defer log.Trace("<<<<< DeleteDevice")
 
 	return cerrors.NewChapiError(cerrors.Unimplemented, errorMessageNotYetImplemented)
 }
 
 // OfflineDevice will offline the given device from the host
 func (driver *ChapiServer) OfflineDevice(serialNumber string) error {
-	log.Infof(">>>>> OfflineDevice called, serialNumber=%v", serialNumber)
-	defer log.Info("<<<<< OfflineDevice")
+	log.Tracef(">>>>> OfflineDevice called, serialNumber=%v", serialNumber)
+	defer log.Trace("<<<<< OfflineDevice")
 	multipathPlugin := multipath.NewMultipathPlugin()
 
 	// Enumerate basic details for the serial number
@@ -301,8 +301,8 @@ func (driver *ChapiServer) OfflineDevice(serialNumber string) error {
 
 // CreateFileSystem writes the given file system to the device with the given serial number
 func (driver *ChapiServer) CreateFileSystem(serialNumber string, filesystem string) error {
-	log.Infof(">>>>> CreateFileSystem called, serialNumber=%v, filesystem=%v", serialNumber, filesystem)
-	defer log.Info("<<<<< CreateFileSystem")
+	log.Tracef(">>>>> CreateFileSystem called, serialNumber=%v, filesystem=%v", serialNumber, filesystem)
+	defer log.Trace("<<<<< CreateFileSystem")
 	multipathPlugin := multipath.NewMultipathPlugin()
 
 	// Enumerate basic details for the serial number
@@ -321,8 +321,8 @@ func (driver *ChapiServer) CreateFileSystem(serialNumber string, filesystem stri
 
 // GetMounts reports all mounts on this host for the specified Nimble volume
 func (driver *ChapiServer) GetMounts(serialNumber string) ([]*model.Mount, error) {
-	log.Infof(">>>>> GetMounts called, serialNumber=%v", serialNumber)
-	defer log.Info("<<<<< GetMounts")
+	log.Tracef(">>>>> GetMounts called, serialNumber=%v", serialNumber)
+	defer log.Trace("<<<<< GetMounts")
 
 	// Route request to the mount package to get the mounts
 	mountPlugin := mount.NewMounter()
@@ -341,8 +341,8 @@ func (driver *ChapiServer) GetMounts(serialNumber string) ([]*model.Mount, error
 
 // GetAllMountDetails enumerates the specified mount point ID
 func (driver *ChapiServer) GetAllMountDetails(serialNumber string, mountId string) ([]*model.Mount, error) {
-	log.Infof(">>>>> GetMount called, serialNumber=%v, mountPointID=%v", serialNumber, mountId)
-	defer log.Info("<<<<< GetMount")
+	log.Tracef(">>>>> GetMount called, serialNumber=%v, mountPointID=%v", serialNumber, mountId)
+	defer log.Trace("<<<<< GetMount")
 
 	// Route request to the mount package to get the mounts
 	mountPlugin := mount.NewMounter()
@@ -361,8 +361,8 @@ func (driver *ChapiServer) GetAllMountDetails(serialNumber string, mountId strin
 
 // CreateMount mounts the given device to the given mount point
 func (driver *ChapiServer) CreateMount(serialNumber string, mountPoint string, fsOptions *model.FileSystemOptions) (*model.Mount, error) {
-	log.Infof(">>>>> MountDevice called, serialNumber=%v, mountPoint=%v, fsOptions=%v", serialNumber, mountPoint, fsOptions)
-	defer log.Info("<<<<< MountDevice")
+	log.Tracef(">>>>> MountDevice called, serialNumber=%v, mountPoint=%v, fsOptions=%v", serialNumber, mountPoint, fsOptions)
+	defer log.Trace("<<<<< MountDevice")
 
 	// Route request to the mount package to create the mount point
 	mountPlugin := mount.NewMounter()
@@ -376,8 +376,8 @@ func (driver *ChapiServer) CreateMount(serialNumber string, mountPoint string, f
 
 // DeleteMount unmounts the given mount point, serialNumber can be optional in the body
 func (driver *ChapiServer) DeleteMount(serialNumber string, mountPointId string) error {
-	log.Infof(">>>>> DeleteMount called, serialNumber=%v, mountPointID=%v", serialNumber, mountPointId)
-	defer log.Info("<<<<< DeleteMount")
+	log.Tracef(">>>>> DeleteMount called, serialNumber=%v, mountPointID=%v", serialNumber, mountPointId)
+	defer log.Trace("<<<<< DeleteMount")
 
 	// Route request to the mount package to delete the mount point
 	mountPlugin := mount.NewMounter()
@@ -386,8 +386,8 @@ func (driver *ChapiServer) DeleteMount(serialNumber string, mountPointId string)
 
 // CreateBindMount unmounts the given mount point
 func (driver *ChapiServer) CreateBindMount(sourceMount string, targetMount string, bindType string) (*model.Mount, error) {
-	log.Infof(">>>>> CreateBindMount called, sourceMount=%s, targetMount=%s bindType=%s", sourceMount, targetMount, bindType)
-	defer log.Info("<<<<< CreateBindMount")
+	log.Tracef(">>>>> CreateBindMount called, sourceMount=%s, targetMount=%s bindType=%s", sourceMount, targetMount, bindType)
+	defer log.Trace("<<<<< CreateBindMount")
 
 	return nil, cerrors.NewChapiError(cerrors.Unimplemented, errorMessageNotYetImplemented)
 }
@@ -400,8 +400,8 @@ func (driver *ChapiServer) CreateBindMount(sourceMount string, targetMount strin
 // about the given serial number.  If multiple volumes share that serial number (e.g. multipath
 // not configured properly), this routine will fail the request.
 func (driver *ChapiServer) getSingleDeviceSummary(serialNumber string) (*model.Device, error) {
-	log.Infof(">>>>> getSingleDeviceSummary called, serialNumber=%v", serialNumber)
-	defer log.Info("<<<<< getSingleDeviceSummary")
+	log.Tracef(">>>>> getSingleDeviceSummary called, serialNumber=%v", serialNumber)
+	defer log.Trace("<<<<< getSingleDeviceSummary")
 
 	// Enumerate the device details for the provided serial number
 	devices, err := driver.GetDevices(serialNumber)

--- a/chapi2/handler/handler_windows.go
+++ b/chapi2/handler/handler_windows.go
@@ -41,7 +41,7 @@ func init() {
 	programDataPath := os.Getenv("ProgramData")
 	if programDataPath == "" {
 		programDataPath = `C:\ProgramData`
-		log.Infof("Unable to enumerate ProgramData folder, using default folder %v", programDataPath)
+		log.Tracef("Unable to enumerate ProgramData folder, using default folder %v", programDataPath)
 	}
 
 	// Set configDir path
@@ -62,8 +62,8 @@ func init() {
 //@Success 200 {array} Hosts
 //@Router /keyfile/ [get]
 func GetKeyfile(w http.ResponseWriter, r *http.Request) {
-	log.Infof(">>>>> getKeyfile called, chapiKeyFilePath=%v", chapiKeyFilePath)
-	defer log.Info("<<<<< getKeyfile")
+	log.Tracef(">>>>> getKeyfile called, chapiKeyFilePath=%v", chapiKeyFilePath)
+	defer log.Trace("<<<<< getKeyfile")
 
 	var chapiResp Response
 	chapiResp.Data = model.KeyFileInfo{Path: chapiKeyFilePath}
@@ -126,18 +126,18 @@ func validateRequestHeader(w http.ResponseWriter, r *http.Request) bool {
 // InitChapiInstanceData is called to initialize our CHAPI instance data.  The CHAPI TCP port is
 // provided as input.
 func InitChapiInstanceData(port int) (err error) {
-	log.Infof(">>>>> initChapiInstanceData, port=%v", port)
-	defer log.Info("<<<<< initChapiInstanceData")
+	log.Tracef(">>>>> initChapiInstanceData, port=%v", port)
+	defer log.Trace("<<<<< initChapiInstanceData")
 
 	// Create the CHAPI port text file
-	log.Infof("CHAPI port file location %v", chapiPortFilePath)
+	log.Tracef("CHAPI port file location %v", chapiPortFilePath)
 	err = initChapiFileData(chapiPortFilePath, strconv.Itoa(port)+"\r\n")
 	if err != nil {
 		return err
 	}
 
 	// Create the CHAPI key file
-	log.Infof("CHAPI key file location %v", chapiKeyFilePath)
+	log.Tracef("CHAPI key file location %v", chapiKeyFilePath)
 	err = initChapiFileData(chapiKeyFilePath, chapiKeyGUID+"\r\n")
 	if err != nil {
 		return err
@@ -187,8 +187,8 @@ func initChapiFileData(filePath string, fileText string) error {
 // setAdministratorOnlyAccess sets the ACLs for the given file such that only processes with Administrator
 // privileges can access it.
 func setAdministratorOnlyAccess(filepath string) error {
-	log.Infof(">>>>> setAdministratorOnlyAccess, filepath=%v", filepath)
-	defer log.Info("<<<<< setAdministratorOnlyAccess")
+	log.Tracef(">>>>> setAdministratorOnlyAccess, filepath=%v", filepath)
+	defer log.Trace("<<<<< setAdministratorOnlyAccess")
 
 	// Allocate and initialize our security identifier (SID)
 	identAuth := windows.SECURITY_NT_AUTHORITY

--- a/chapi2/host/host_linux.go
+++ b/chapi2/host/host_linux.go
@@ -40,7 +40,7 @@ func getHostId() (string, error) {
 
 // getIPV4NetworkAddress returns network address for given ipv4 address and netmask
 func getIPV4NetworkAddress(ipv4Address, netMask string) (networkAddress string, err error) {
-	log.Info("GetIPV4NetworkAddress called with ", ipv4Address, " mask ", netMask)
+	log.Trace("GetIPV4NetworkAddress called with ", ipv4Address, " mask ", netMask)
 	if ipv4Address == "" || netMask == "" {
 		return "", cerrors.NewChapiErrorf(cerrors.InvalidArgument, errorMessageInvalidIpv4Address)
 	}
@@ -69,22 +69,22 @@ func getIPV4NetworkAddress(ipv4Address, netMask string) (networkAddress string, 
 		networkOctets[index] = strconv.FormatUint(networkOctet, 10)
 	}
 	networkAddress = fmt.Sprintf("%s.%s.%s.%s", networkOctets[0], networkOctets[1], networkOctets[2], networkOctets[3])
-	log.Info("network address being returned ", networkAddress)
+	log.Trace("network address being returned ", networkAddress)
 	return networkAddress, nil
 }
 
 //getNetworkInterfaces : get the array of network interfaces
 func getNetworkInterfaces() ([]*model.Network, error) {
-	log.Info(">>>>> GetNetworkInterfaces")
-	defer log.Info("<<<<< GetNetworkInterfaces")
+	log.Trace(">>>>> GetNetworkInterfaces")
+	defer log.Trace("<<<<< GetNetworkInterfaces")
 
 	interfaces, err := getInterfacesIPAddr()
 	return interfaces, err
 }
 
 func getMaskString(intMask int) string {
-	log.Info(">>>>> getMaskString called with ", intMask)
-	defer log.Info("<<<<< getMaskString")
+	log.Trace(">>>>> getMaskString called with ", intMask)
+	defer log.Trace("<<<<< getMaskString")
 
 	var mask uint64
 	mask = (0xFFFFFFFF << (32 - uint64(intMask))) & 0xFFFFFFFF //intMask is for eg: /24
@@ -97,14 +97,14 @@ func getMaskString(intMask int) string {
 		dmask -= 8
 	}
 	maskV4 := fmt.Sprintf(maskFmt, localmask[0], localmask[1], localmask[2], localmask[3])
-	log.Infof("mask(v4): %s", maskV4)
+	log.Tracef("mask(v4): %s", maskV4)
 
 	return maskV4
 }
 
 func getInterfacesIPAddr() ([]*model.Network, error) {
-	log.Info(">>>>> getInterfacesIpAddr")
-	defer log.Info("<<<<< getInterfacesIPAddr")
+	log.Trace(">>>>> getInterfacesIpAddr")
+	defer log.Trace("<<<<< getInterfacesIPAddr")
 
 	var nics []*model.Network
 	var nic *model.Network
@@ -115,17 +115,17 @@ func getInterfacesIPAddr() ([]*model.Network, error) {
 	}
 	outArr := strings.Split(out, "\n")
 	for _, line := range outArr {
-		log.Info("line :", line)
+		log.Trace("line :", line)
 		r := regexp.MustCompile(nameMtuStateKeyPattern)
 		if r.MatchString(line) {
 			matchedMap := util.FindStringSubmatchMap(line, r)
 			if nic != nil {
 				nics = append(nics, nic)
-				log.Info("Added :", nic.Name)
+				log.Trace("Added :", nic.Name)
 			}
 			mtu, er := strconv.ParseInt(matchedMap["Mtu"], 10, 32)
 			if er != nil {
-				log.Info("Err :", err)
+				log.Trace("Err :", err)
 				return nics, er
 			}
 			if matchedMap["UP"] == up {
@@ -147,7 +147,7 @@ func getInterfacesIPAddr() ([]*model.Network, error) {
 	}
 	if nic != nil {
 		nics = append(nics, nic)
-		log.Infof("getInterfacesIpAddr added %v to slice of NICs", nic)
+		log.Tracef("getInterfacesIpAddr added %v to slice of NICs", nic)
 	}
 	return nics, err
 }
@@ -159,7 +159,7 @@ func getInterfaceStatus(name string) bool {
 	if err != nil {
 		return false
 	}
-	log.Infoln("Obtained link status using ethtool for", name)
+	log.Traceln("Obtained link status using ethtool for", name)
 	r := regexp.MustCompile(linkStatusPattern)
 	lines := strings.Split(out, "\n")
 	for _, line := range lines {
@@ -171,13 +171,13 @@ func getInterfaceStatus(name string) bool {
 }
 
 func matchIPPattern(line string, nic *model.Network) (*model.Network, error) {
-	log.Infof(">>>> matchIPPattern called with %s", line)
-	defer log.Info("<<<<< matchIPPattern")
+	log.Tracef(">>>> matchIPPattern called with %s", line)
+	defer log.Trace("<<<<< matchIPPattern")
 
 	r := regexp.MustCompile(ipv4AddrKeyPattern)
 	if r.MatchString(line) {
 		matchedMap := util.FindStringSubmatchMap(line, r)
-		log.Info("matched out Map:", matchedMap)
+		log.Trace("matched out Map:", matchedMap)
 
 		mask, er := strconv.ParseInt(matchedMap["Mask"], 10, 64)
 		if er != nil {
@@ -191,7 +191,7 @@ func matchIPPattern(line string, nic *model.Network) (*model.Network, error) {
 		if r.MatchString(line) {
 			matchedMap := util.FindStringSubmatchMap(line, r)
 
-			log.Info("matched out map:", matchedMap)
+			log.Trace("matched out map:", matchedMap)
 			nic.Mac = matchedMap["Mac"]
 
 		} else {
@@ -199,7 +199,7 @@ func matchIPPattern(line string, nic *model.Network) (*model.Network, error) {
 			if r.MatchString(line) {
 				matchedMap := util.FindStringSubmatchMap(line, r)
 
-				log.Info("matched out map:", matchedMap)
+				log.Trace("matched out map:", matchedMap)
 				mask, er := strconv.ParseInt(matchedMap["Mask"], 10, 64)
 				if er != nil {
 					return nic, er
@@ -210,7 +210,7 @@ func matchIPPattern(line string, nic *model.Network) (*model.Network, error) {
 		}
 	}
 
-	log.Infof("matchIPPattern returning %v", nic)
+	log.Tracef("matchIPPattern returning %v", nic)
 	return nic, nil
 }
 

--- a/chapi2/host/host_windows.go
+++ b/chapi2/host/host_windows.go
@@ -31,8 +31,8 @@ var (
 
 //getNetworkInterfaces : get the array of network interfaces
 func getNetworkInterfaces() ([]*model.Network, error) {
-	log.Info(">>>>> getNetworkInterfaces")
-	defer log.Info("<<<<< getNetworkInterfaces")
+	log.Trace(">>>>> getNetworkInterfaces")
+	defer log.Trace("<<<<< getNetworkInterfaces")
 
 	// Start with an empty array of NICs to return
 	var nics []*model.Network
@@ -91,7 +91,7 @@ func getNetworkInterfaces() ([]*model.Network, error) {
 
 			// Skip any cluster IP
 			if isClusterIP {
-				log.Infof("Ignoring cluster IP %v", ipAddress)
+				log.Tracef("Ignoring cluster IP %v", ipAddress)
 				continue
 			}
 
@@ -154,8 +154,8 @@ func getNetworkInterfaces() ([]*model.Network, error) {
 // map of syscall.IpAdapterInfo objects is returned to the caller with the index to the map being
 // the NIC index.
 func getAdaptersInfo() (adapters map[int]*syscall.IpAdapterInfo, err error) {
-	log.Info(">>>>> getAdaptersInfo")
-	defer log.Info("<<<<< getAdaptersInfo")
+	log.Trace(">>>>> getAdaptersInfo")
+	defer log.Trace("<<<<< getAdaptersInfo")
 
 	// We don't know the size of the buffer we'll need to retrieve the information from the Win32
 	// API.  We'll start at 0 and increase as we start enumerating adapters from the API.
@@ -269,7 +269,7 @@ func getDomainName() (string, error) {
 	// We don't expect the query to fail.  If it does, log an informational entry and return an
 	// empty domain string with no error.
 	if err != nil {
-		log.Infof("Domain query failure, computer probably not part of a domain, error=%v", err)
+		log.Tracef("Domain query failure, computer probably not part of a domain, error=%v", err)
 		return "", nil
 	}
 

--- a/windows/ioctl/ioctl_disk_get_drive_geometry_ex.go
+++ b/windows/ioctl/ioctl_disk_get_drive_geometry_ex.go
@@ -91,8 +91,8 @@ type DISK_GEOMETRY_EX struct {
 // GetDiskGeometry issues an IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS to the given volume and
 // returns back the volume's geometry details.
 func GetDiskGeometry(diskNumber uint32) (diskGeometry *DISK_GEOMETRY_EX, err error) {
-	log.Infof(">>>>> GetDiskGeometry, diskNumber=%v", diskNumber)
-	defer log.Info("<<<<< GetDiskGeometry")
+	log.Tracef(">>>>> GetDiskGeometry, diskNumber=%v", diskNumber)
+	defer log.Trace("<<<<< GetDiskGeometry")
 
 	// Convert disk number to a disk path UTF16 string
 	diskPathUTF16 := syscall.StringToUTF16(diskPathFromNumber(diskNumber))
@@ -147,7 +147,7 @@ func GetDiskGeometry(diskNumber uint32) (diskGeometry *DISK_GEOMETRY_EX, err err
 		} else if diskGeometry.DiskPartitionGPT != nil {
 			partitionDetails = fmt.Sprintf("GPT, DiskId=%v", diskGeometry.DiskPartitionGPT.DiskId.String())
 		}
-		log.Infof("DiskSize=%v, Partition={%v}", diskGeometry.DiskSize, partitionDetails)
+		log.Tracef("DiskSize=%v, Partition={%v}", diskGeometry.DiskSize, partitionDetails)
 	} else {
 		// Log error on failure
 		log.Errorf("Error=%v", err)
@@ -158,8 +158,8 @@ func GetDiskGeometry(diskNumber uint32) (diskGeometry *DISK_GEOMETRY_EX, err err
 
 // GetDiskCapacity returns back the given disk's capacity (in bytes)
 func GetDiskCapacity(diskNumber uint32) (diskCapacity uint64, err error) {
-	log.Infof(">>>>> GetDiskCapacity, diskNumber=%v", diskNumber)
-	defer log.Info("<<<<< GetDiskCapacity")
+	log.Tracef(">>>>> GetDiskCapacity, diskNumber=%v", diskNumber)
+	defer log.Trace("<<<<< GetDiskCapacity")
 
 	var diskGeometry *DISK_GEOMETRY_EX
 	if diskGeometry, err = GetDiskGeometry(diskNumber); err == nil && diskGeometry != nil {

--- a/windows/ioctl/ioctl_scsi_get_address.go
+++ b/windows/ioctl/ioctl_scsi_get_address.go
@@ -24,8 +24,8 @@ type SCSI_ADDRESS struct {
 // GetScsiAddress issues an IOCTL_SCSI_GET_ADDRESS to the given device and returns back the
 // device's SCSI_ADDRESS struct.
 func GetScsiAddress(devicePathID string) (scsiAddress *SCSI_ADDRESS, err error) {
-	log.Infof(">>>>> GetScsiAddress, devicePathID=%v", devicePathID)
-	defer log.Info("<<<<< GetScsiAddress")
+	log.Tracef(">>>>> GetScsiAddress, devicePathID=%v", devicePathID)
+	defer log.Trace("<<<<< GetScsiAddress")
 
 	// Convert device path to a UTF16 string (strip any trailing backslash)
 	devicePathID = strings.TrimRight(devicePathID, `\`)
@@ -59,7 +59,7 @@ func GetScsiAddress(devicePathID string) (scsiAddress *SCSI_ADDRESS, err error) 
 
 	// Log the results
 	if err == nil {
-		log.Infof("SCSI_ADDRESS Lengh=%v, ID=%02X:%02X:%02X:%02X", scsiAddress.Length, scsiAddress.PortNumber, scsiAddress.PathId, scsiAddress.TargetId, scsiAddress.Lun)
+		log.Tracef("SCSI_ADDRESS Lengh=%v, ID=%02X:%02X:%02X:%02X", scsiAddress.Length, scsiAddress.PortNumber, scsiAddress.PathId, scsiAddress.TargetId, scsiAddress.Lun)
 	} else {
 		// Log error on failure
 		log.Errorf("Error=%v", err)

--- a/windows/ioctl/ioctl_volume_get_volume_disk_extents.go
+++ b/windows/ioctl/ioctl_volume_get_volume_disk_extents.go
@@ -23,8 +23,8 @@ type DISK_EXTENT struct {
 // GetVolumeDiskExtents issues an IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS to the given volume and
 // returns back the volume's DISK_EXTENT array.
 func GetVolumeDiskExtents(volumePathID string) (diskExtents []DISK_EXTENT, err error) {
-	log.Infof(">>>>> GetVolumeDiskExtents, volumePathID=%v", volumePathID)
-	defer log.Info("<<<<< GetVolumeDiskExtents")
+	log.Tracef(">>>>> GetVolumeDiskExtents, volumePathID=%v", volumePathID)
+	defer log.Trace("<<<<< GetVolumeDiskExtents")
 
 	// Convert volume path to a UTF16 string (strip any trailing backslash)
 	volumePathID = strings.TrimRight(volumePathID, `\`)
@@ -85,7 +85,7 @@ func GetVolumeDiskExtents(volumePathID string) (diskExtents []DISK_EXTENT, err e
 	// Log the results
 	if err == nil {
 		for _, extent := range diskExtents {
-			log.Infof("DiskNumber=%v, StartingOffset=%v, ExtentLength=%v", extent.DiskNumber, extent.StartingOffset, extent.ExtentLength)
+			log.Tracef("DiskNumber=%v, StartingOffset=%v, ExtentLength=%v", extent.DiskNumber, extent.StartingOffset, extent.ExtentLength)
 		}
 	} else {
 		// Log error on failure

--- a/windows/iscsidsc/add_iscsi_send_target_portal.go
+++ b/windows/iscsidsc/add_iscsi_send_target_portal.go
@@ -15,8 +15,8 @@ import (
 // AddIScsiSendTargetPortal - Go wrapped Win32 API - AddIScsiSendTargetPortalW()
 // https://docs.microsoft.com/en-us/windows/win32/api/iscsidsc/nf-iscsidsc-addiscsisendtargetportalw
 func AddIScsiSendTargetPortal(initiatorInstance string, initiatorPortNumber uint32, address string) (err error) {
-	log.Infof(">>>>> AddIScsiSendTargetportal, initiatorInstance=%v, initiatorPortNumber=%v, address=%v", initiatorInstance, initiatorPortNumber, address)
-	defer log.Infoln("<<<<< AddIScsiSendTargetPortal")
+	log.Tracef(">>>>> AddIScsiSendTargetportal, initiatorInstance=%v, initiatorPortNumber=%v, address=%v", initiatorInstance, initiatorPortNumber, address)
+	defer log.Traceln("<<<<< AddIScsiSendTargetPortal")
 
 	// Convert initiatorInstance into a raw equivalent so that we can send it to the iSCSI API
 	initiatorNameUTF16 := syscall.StringToUTF16(initiatorInstance)

--- a/windows/iscsidsc/get_devices_for_iscsi_session.go
+++ b/windows/iscsidsc/get_devices_for_iscsi_session.go
@@ -16,8 +16,8 @@ import (
 // GetDevicesForIScsiSession - Go wrapped Win32 API - GetDevicesForIScsiSessionW()
 // https://docs.microsoft.com/en-us/windows/desktop/api/iscsidsc/nf-iscsidsc-getdevicesforiscsisessionw
 func GetDevicesForIScsiSession(sessionID ISCSI_UNIQUE_SESSION_ID) (devicesOnSession []*ISCSI_DEVICE_ON_SESSION, err error) {
-	log.Info(">>>>> GetDevicesForIScsiSession")
-	defer log.Info("<<<<< GetDevicesForIScsiSession")
+	log.Trace(">>>>> GetDevicesForIScsiSession")
+	defer log.Trace("<<<<< GetDevicesForIScsiSession")
 
 	//
 	// Note that the algorithm employed below is ported from C# GetDevicesForSession() including
@@ -74,7 +74,7 @@ func GetDevicesForIScsiSession(sessionID ISCSI_UNIQUE_SESSION_ID) (devicesOnSess
 		}
 
 		if (iscsiErr == ISDSC_DEVICE_BUSY_ON_SESSION) || (iscsiErr == ISDSC_SESSION_BUSY) || (iscsiErr == uintptr(syscall.ERROR_INSUFFICIENT_BUFFER)) {
-			log.Infof("GetDevicesForIScsiSession status returned, iscsiErr=%v, attempt %v of %v", iscsiErr, i+1, RetryCount)
+			log.Tracef("GetDevicesForIScsiSession status returned, iscsiErr=%v, attempt %v of %v", iscsiErr, i+1, RetryCount)
 
 			// In PRT-312 and PRT-309, we know that a bug in Microsoft's iSCSI library can
 			// return ERROR_INSUFFICIENT_BUFFER.  If this error is detected, we will not
@@ -94,9 +94,9 @@ func GetDevicesForIScsiSession(sessionID ISCSI_UNIQUE_SESSION_ID) (devicesOnSess
 		log.Error(logIscsiFailure, err.Error())
 	} else if len(devicesOnSession) > 0 {
 		// Log the enumerated devices per session
-		log.Infof("SessionID=%x-%x", sessionID.AdapterUnique, sessionID.AdapterSpecific)
+		log.Tracef("SessionID=%x-%x", sessionID.AdapterUnique, sessionID.AdapterSpecific)
 		for _, element := range devicesOnSession {
-			log.Infof("    ScsiAddress=%02X:%02X:%02X:%02X, DeviceNumber=%v, LegacyName=%v, TargetName=%v",
+			log.Tracef("    ScsiAddress=%02X:%02X:%02X:%02X, DeviceNumber=%v, LegacyName=%v, TargetName=%v",
 				element.ScsiAddress.PortNumber, element.ScsiAddress.PathID, element.ScsiAddress.TargetID, element.ScsiAddress.Lun,
 				element.StorageDeviceNumber.DeviceNumber, element.LegacyName, element.TargetName)
 		}

--- a/windows/iscsidsc/get_iscsi_initiator_node_name.go
+++ b/windows/iscsidsc/get_iscsi_initiator_node_name.go
@@ -15,8 +15,8 @@ import (
 // GetIScsiInitiatorNodeName - Go wrapped Win32 API - GetIScsiInitiatorNodeNameW()
 // https://docs.microsoft.com/en-us/windows/desktop/api/iscsidsc/nf-iscsidsc-getiscsiinitiatornodenamew
 func GetIScsiInitiatorNodeName() (initiatorNodeName string, err error) {
-	log.Info(">>>>> GetIScsiInitiatorNodeName")
-	defer log.Info("<<<<< GetIScsiInitiatorNodeName")
+	log.Trace(">>>>> GetIScsiInitiatorNodeName")
+	defer log.Trace("<<<<< GetIScsiInitiatorNodeName")
 
 	// Allocate a data buffer large enough to hold the initiator name
 	dataBuffer := make([]uint16, MAX_ISCSI_NAME_LEN+1)
@@ -25,7 +25,7 @@ func GetIScsiInitiatorNodeName() (initiatorNodeName string, err error) {
 	if iscsiErr, _, _ := procGetIScsiInitiatorNodeNameW.Call(uintptr(unsafe.Pointer(&dataBuffer[0]))); iscsiErr == ERROR_SUCCESS {
 		// Convert initiator name from UTF16 into a Go string
 		initiatorNodeName = syscall.UTF16ToString(dataBuffer[:])
-		log.Info("initiatorNodeName=", initiatorNodeName)
+		log.Trace("initiatorNodeName=", initiatorNodeName)
 	} else {
 		// If an unexpected error occurs, initialize error object and log failure
 		err = syscall.Errno(iscsiErr)

--- a/windows/iscsidsc/get_iscsi_session_list.go
+++ b/windows/iscsidsc/get_iscsi_session_list.go
@@ -15,8 +15,8 @@ import (
 // GetIscsiSessionList - Go wrapped Win32 API - GetIScsiSessionListW()
 // https://docs.microsoft.com/en-us/windows/desktop/api/iscsidsc/nf-iscsidsc-getiscsisessionlistw
 func GetIscsiSessionList() (iscsiSessions []*ISCSI_SESSION_INFO, err error) {
-	log.Info(">>>>> GetIscsiSessionList")
-	defer log.Info("<<<<< GetIscsiSessionList")
+	log.Trace(">>>>> GetIscsiSessionList")
+	defer log.Trace("<<<<< GetIscsiSessionList")
 
 	// NWT-3303.  We're seeing Win32 GetIscsiSessionList return ERROR_INSUFFICIENT_BUFFER during
 	// an array failover. The first call to GetIScsiSessionListW returns ERROR_INSUFFICIENT_BUFFER
@@ -64,12 +64,12 @@ func GetIscsiSessionList() (iscsiSessions []*ISCSI_SESSION_INFO, err error) {
 	} else {
 		// Log the sessions
 		for index, iscsiSession := range iscsiSessions {
-			log.Infof("iscsiSession[%v], SessionId=%x-%x, TargetName=%v, ConnectionCount=%v",
+			log.Tracef("iscsiSession[%v], SessionId=%x-%x, TargetName=%v, ConnectionCount=%v",
 				index, iscsiSession.SessionID.AdapterUnique, iscsiSession.SessionID.AdapterSpecific,
 				iscsiSession.TargetName, len(iscsiSession.Connections))
 			// Log the connections per session
 			for _, iscsiConnection := range iscsiSession.Connections {
-				log.Infof("    ConnectionIdId=%x-%x, InitiatorAddress=%v, InitiatorSocket=%v, TargetAddress=%v, TargetSocket=%v",
+				log.Tracef("    ConnectionIdId=%x-%x, InitiatorAddress=%v, InitiatorSocket=%v, TargetAddress=%v, TargetSocket=%v",
 					iscsiConnection.ConnectionID.AdapterUnique, iscsiConnection.ConnectionID.AdapterSpecific,
 					iscsiConnection.InitiatorAddress, iscsiConnection.InitiatorSocket,
 					iscsiConnection.TargetAddress, iscsiConnection.TargetSocket)

--- a/windows/iscsidsc/get_iscsi_version_information.go
+++ b/windows/iscsidsc/get_iscsi_version_information.go
@@ -15,13 +15,13 @@ import (
 // GetIScsiVersionInformation - Go wrapped Win32 API - GetIScsiVersionInformation()
 // https://docs.microsoft.com/en-us/windows/desktop/api/iscsidsc/nf-iscsidsc-getiscsiversioninformation
 func GetIScsiVersionInformation() (versionInfo ISCSI_VERSION_INFO, err error) {
-	log.Info(">>>>> GetIScsiVersionInformation")
-	defer log.Info("<<<<< GetIScsiVersionInformation")
+	log.Trace(">>>>> GetIScsiVersionInformation")
+	defer log.Trace("<<<<< GetIScsiVersionInformation")
 
 	// Call the Win32 API
 	if iscsiErr, _, _ := procGetIScsiVersionInformation.Call(uintptr(unsafe.Pointer(&versionInfo))); iscsiErr == ERROR_SUCCESS {
 		// Log the API results
-		log.Infof("versionInfo=%v.%v.%v", versionInfo.MajorVersion, versionInfo.MinorVersion, versionInfo.BuildNumber)
+		log.Tracef("versionInfo=%v.%v.%v", versionInfo.MajorVersion, versionInfo.MinorVersion, versionInfo.BuildNumber)
 	} else {
 		// If an unexpected error occurs, initialize error object and log failure
 		err = syscall.Errno(iscsiErr)

--- a/windows/iscsidsc/login_iscsi_target.go
+++ b/windows/iscsidsc/login_iscsi_target.go
@@ -17,8 +17,8 @@ import (
 // LoginIScsiTargetEx is similar to our C# WindowsBridge.cs LoginTarget() routine.  It will both log
 // into the iSCSI target as well as make a persistent connection (if requested)
 func LoginIScsiTargetEx(targetName string, initiatorInstance string, initiatorPortNumber uint32, targetPortal *ISCSI_TARGET_PORTAL, headerDigest ISCSI_DIGEST_TYPES, dataDigest ISCSI_DIGEST_TYPES, chapUsername string, chapPassword string, isPersistent bool) (uniqueSessionID *ISCSI_UNIQUE_SESSION_ID, uniqueConnectionID *ISCSI_UNIQUE_CONNECTION_ID, err error) {
-	log.Info(">>>>> LoginIScsiTargetEx")
-	defer log.Info("<<<<< LoginIScsiTargetEx")
+	log.Trace(">>>>> LoginIScsiTargetEx")
+	defer log.Trace("<<<<< LoginIScsiTargetEx")
 
 	// Start by calling our base loginIScsiTarget routine with "isPersistent" set to false.  We do this
 	// so that we actually make a connection.  If we set "isPersistent" to true, it would just make a
@@ -44,9 +44,9 @@ func LoginIScsiTargetEx(targetName string, initiatorInstance string, initiatorPo
 // loginIScsiTarget wraps the iSCSI discovery LoginIScsiTarget() API.  It's only for internal
 // package use as we recommend the public LoginIScsiTarget() function be used instead.
 func loginIScsiTarget(targetName string, initiatorInstance string, initiatorPortNumber uint32, targetPortal *ISCSI_TARGET_PORTAL, headerDigest ISCSI_DIGEST_TYPES, dataDigest ISCSI_DIGEST_TYPES, chapUsername string, chapPassword string, isPersistent bool) (uniqueSessionID *ISCSI_UNIQUE_SESSION_ID, uniqueConnectionID *ISCSI_UNIQUE_CONNECTION_ID, err error) {
-	log.Infof(">>>>> loginIScsiTarget, targetName=%v, initiatorPortNumber=%v, targetPortal=%v, headerDigest=%v, dataDigest=%v, CHAP=%v:%v, isPersistent=%v",
+	log.Tracef(">>>>> loginIScsiTarget, targetName=%v, initiatorPortNumber=%v, targetPortal=%v, headerDigest=%v, dataDigest=%v, CHAP=%v:%v, isPersistent=%v",
 		targetName, initiatorPortNumber, targetPortal, headerDigest, dataDigest, chapUsername != "", chapPassword != "", isPersistent)
-	defer log.Info("<<<<< loginIScsiTarget")
+	defer log.Trace("<<<<< loginIScsiTarget")
 
 	// iscsiLoginOptions is composed of ISCSI_LOGIN_OPTIONS plus additional storage for any CHAP
 	// username/password we need to pass to the Windows iSCSI initiator.  Nimble Storage has a
@@ -155,8 +155,8 @@ func loginIScsiTarget(targetName string, initiatorInstance string, initiatorPort
 		log.Error(logIscsiFailure, err.Error())
 	} else {
 		// Log the return data
-		log.Infof("uniqueSessionID=%x-%x", uniqueSessionID.AdapterUnique, uniqueSessionID.AdapterSpecific)
-		log.Infof("uniqueConnectionID=%x-%x", uniqueConnectionID.AdapterUnique, uniqueConnectionID.AdapterSpecific)
+		log.Tracef("uniqueSessionID=%x-%x", uniqueSessionID.AdapterUnique, uniqueSessionID.AdapterSpecific)
+		log.Tracef("uniqueConnectionID=%x-%x", uniqueConnectionID.AdapterUnique, uniqueConnectionID.AdapterSpecific)
 	}
 
 	// If an error occurred, we'll clear the session/connection IDs

--- a/windows/iscsidsc/logout_iscsi_target.go
+++ b/windows/iscsidsc/logout_iscsi_target.go
@@ -18,8 +18,8 @@ import (
 // LogoutIScsiTarget - Go wrapped Win32 API - LogoutIScsiTarget()
 // https://docs.microsoft.com/en-us/windows/desktop/api/iscsidsc/nf-iscsidsc-logoutiscsitarget
 func LogoutIScsiTarget(sessionID ISCSI_UNIQUE_SESSION_ID) (err error) {
-	log.Infof(">>>>> LogoutIScsiTarget, sessionID=%x-%x", sessionID.AdapterUnique, sessionID.AdapterSpecific)
-	defer log.Info("<<<<< LogoutIScsiTarget")
+	log.Tracef(">>>>> LogoutIScsiTarget, sessionID=%x-%x", sessionID.AdapterUnique, sessionID.AdapterSpecific)
+	defer log.Trace("<<<<< LogoutIScsiTarget")
 
 	// Call the Win32 LogoutIScsiTarget API to logout the session.
 	// In our C# code, we would terminate the thread if it hung more than 60 seconds.  We can't simply
@@ -44,8 +44,8 @@ func LogoutIScsiTarget(sessionID ISCSI_UNIQUE_SESSION_ID) (err error) {
 // The removePersistentTarget flag can be set to true if the caller also wants any persistent
 // logins to be removed as well.
 func LogoutIScsiTargetAll(targetName string, removePersistentTarget bool) (err error) {
-	log.Infof(">>>>> LogoutIScsiTargetAll, targetName=%v, removePersistentTarget=%v", targetName, removePersistentTarget)
-	defer log.Info("<<<<< LogoutIScsiTargetAll")
+	log.Tracef(">>>>> LogoutIScsiTargetAll, targetName=%v, removePersistentTarget=%v", targetName, removePersistentTarget)
+	defer log.Trace("<<<<< LogoutIScsiTargetAll")
 
 	// Remove persistent logins?
 	if removePersistentTarget {
@@ -118,7 +118,7 @@ func LogoutIScsiTargetAll(targetName string, removePersistentTarget bool) (err e
 
 				// If we're past our alloted timeouts, set timeoutDetection flag and break out of loop
 				if (elapsedLogoutSession >= maxDurationPerSessionLogout) || (elapsedLogoutSession >= maxDurationTotal) {
-					log.Infof("Logout timeout expired, elapsedLogoutSession=%v, elapsedLogoutTarget=%v", elapsedLogoutSession, elapsedLogoutTarget)
+					log.Tracef("Logout timeout expired, elapsedLogoutSession=%v, elapsedLogoutTarget=%v", elapsedLogoutSession, elapsedLogoutTarget)
 					timeoutDetection = true
 					break
 				}

--- a/windows/iscsidsc/remove_iscsi_persistent_target.go
+++ b/windows/iscsidsc/remove_iscsi_persistent_target.go
@@ -16,8 +16,8 @@ import (
 // RemoveIScsiPersistentTarget - Go wrapped Win32 API - RemoveIScsiPersistentTargetW()
 // https://docs.microsoft.com/is-is/windows/desktop/api/iscsidsc/nf-iscsidsc-removeiscsipersistenttargetw
 func RemoveIScsiPersistentTarget(initiatorInstance string, initiatorPortNumber uint32, targetName string, targetPortal ISCSI_TARGET_PORTAL) (err error) {
-	log.Infof(">>>>> RemoveIScsiPersistentTarget, initiatorInstance=%v, initiatorPortNumber=%v, targetName=%v", initiatorInstance, initiatorPortNumber, targetName)
-	defer log.Info("<<<<< RemoveIScsiPersistentTarget")
+	log.Tracef(">>>>> RemoveIScsiPersistentTarget, initiatorInstance=%v, initiatorPortNumber=%v, targetName=%v", initiatorInstance, initiatorPortNumber, targetName)
+	defer log.Trace("<<<<< RemoveIScsiPersistentTarget")
 
 	// Convert initiatorInstance, targetName, and targetPortal into raw equivalents so that we can
 	// send them to the iSCSI API.
@@ -39,8 +39,8 @@ func RemoveIScsiPersistentTarget(initiatorInstance string, initiatorPortNumber u
 // RemoveIScsiPersistentTargetAll is a extended wrapper around the RemoveIScsiPersistentTarget API.
 // What it does is remove *all* persistent logins for the specified target.
 func RemoveIScsiPersistentTargetAll(targetName string) (err error) {
-	log.Infof(">>>>> RemoveIScsiPersistentTargetAll, targetName=%v", targetName)
-	defer log.Info("<<<<< RemoveIScsiPersistentTargetAll")
+	log.Tracef(">>>>> RemoveIScsiPersistentTargetAll, targetName=%v", targetName)
+	defer log.Trace("<<<<< RemoveIScsiPersistentTargetAll")
 
 	// Start by querying all the iSCSI persistent logins on this host
 	persistentLogins, err := ReportIScsiPersistentLogins()

--- a/windows/iscsidsc/report_active_iscsi_target_mappings.go
+++ b/windows/iscsidsc/report_active_iscsi_target_mappings.go
@@ -15,8 +15,8 @@ import (
 // ReportActiveIScsiTargetMappings - Go wrapped Win32 API - ReportActiveIScsiTargetMappingsW()
 // https://docs.microsoft.com/en-us/windows/desktop/api/iscsidsc/nf-iscsidsc-reportactiveiscsitargetmappingsw
 func ReportActiveIScsiTargetMappings() (targetMappings []*ISCSI_TARGET_MAPPING, err error) {
-	log.Info(">>>>> ReportActiveIScsiTargetMappings")
-	defer log.Info("<<<<< ReportActiveIScsiTargetMappings")
+	log.Trace(">>>>> ReportActiveIScsiTargetMappings")
+	defer log.Trace("<<<<< ReportActiveIScsiTargetMappings")
 
 	// Call ReportActiveIScsiTargetMappingsW  to find the required buffer size
 	var bufferSize, mappingCount uint32
@@ -46,11 +46,11 @@ func ReportActiveIScsiTargetMappings() (targetMappings []*ISCSI_TARGET_MAPPING, 
 	} else {
 		// Log the target mappings
 		for index, targetMapping := range targetMappings {
-			log.Infof("targetMappings[%v], TargetName=%v, OSDeviceName=%v, SessionId=%x-%x, OSBusNumber=%02Xh, OSTargetNumber=%02Xh",
+			log.Tracef("targetMappings[%v], TargetName=%v, OSDeviceName=%v, SessionId=%x-%x, OSBusNumber=%02Xh, OSTargetNumber=%02Xh",
 				index, targetMapping.TargetName, targetMapping.OSDeviceName, targetMapping.SessionId.AdapterUnique, targetMapping.SessionId.AdapterSpecific,
 				targetMapping.OSBusNumber, targetMapping.OSTargetNumber)
 			for index2, lun := range targetMapping.LUNList {
-				log.Infof("    LUNList[%v], OSLUN=%02Xh, TargetLUN=%04Xh", index2, lun.OSLUN, lun.TargetLUN)
+				log.Tracef("    LUNList[%v], OSLUN=%02Xh, TargetLUN=%04Xh", index2, lun.OSLUN, lun.TargetLUN)
 			}
 
 		}

--- a/windows/iscsidsc/report_iscsi_persistent_logins.go
+++ b/windows/iscsidsc/report_iscsi_persistent_logins.go
@@ -15,8 +15,8 @@ import (
 // ReportIScsiPersistentLogins - Go wrapped Win32 API - ReportIScsiPersistentLoginsW()
 // https://docs.microsoft.com/en-us/windows/desktop/api/iscsidsc/nf-iscsidsc-reportiscsipersistentloginsw
 func ReportIScsiPersistentLogins() (persistentLogins []*PERSISTENT_ISCSI_LOGIN_INFO, err error) {
-	log.Info(">>>>> ReportIScsiPersistentLogins")
-	defer log.Info("<<<<< ReportIScsiPersistentLogins")
+	log.Trace(">>>>> ReportIScsiPersistentLogins")
+	defer log.Trace("<<<<< ReportIScsiPersistentLogins")
 
 	// Determine the persistent login count on this host
 	var count, bufferSizeNeeded uint32
@@ -55,7 +55,7 @@ func ReportIScsiPersistentLogins() (persistentLogins []*PERSISTENT_ISCSI_LOGIN_I
 	} else {
 		// Log the enumerated persistent logins
 		for index, persistentLogin := range persistentLogins {
-			log.Infof("persistentLogins[%v], TargetName=%v, InitiatorPortNumber=%v, TargetPortal.Address=%v, Mapping=%v, InformationSpecified=%v, LoginFlags=%v",
+			log.Tracef("persistentLogins[%v], TargetName=%v, InitiatorPortNumber=%v, TargetPortal.Address=%v, Mapping=%v, InformationSpecified=%v, LoginFlags=%v",
 				index, persistentLogin.TargetName,
 				persistentLogin.InitiatorPortNumber, persistentLogin.TargetPortal.Address, persistentLogin.Mappings != nil,
 				persistentLogin.LoginOptions.InformationSpecified, persistentLogin.LoginOptions.LoginFlags)

--- a/windows/iscsidsc/report_iscsi_send_target_portals.go
+++ b/windows/iscsidsc/report_iscsi_send_target_portals.go
@@ -15,8 +15,8 @@ import (
 // ReportIScsiSendTargetPortals - Go wrapped Win32 API - ReportIScsiSendTargetPortalsW()
 // https://docs.microsoft.com/is-is/windows/desktop/api/iscsidsc/nf-iscsidsc-reportiscsisendtargetportalsw
 func ReportIScsiSendTargetPortals() (targetPortals []*ISCSI_TARGET_PORTAL_INFO, err error) {
-	log.Info(">>>>> ReportIScsiSendTargetPortals")
-	defer log.Info("<<<<< ReportIScsiSendTargetPortals")
+	log.Trace(">>>>> ReportIScsiSendTargetPortals")
+	defer log.Trace("<<<<< ReportIScsiSendTargetPortals")
 
 	// Determine the target portal count on this host
 	var portalCount uint32
@@ -45,7 +45,7 @@ func ReportIScsiSendTargetPortals() (targetPortals []*ISCSI_TARGET_PORTAL_INFO, 
 	} else {
 		// Log the enumerated target portals
 		for index, targetPortal := range targetPortals {
-			log.Infof("targetPortals[%v], Address=%v, InitiatorPortNumber=%v", index, targetPortal.Address, int32(targetPortal.InitiatorPortNumber))
+			log.Tracef("targetPortals[%v], Address=%v, InitiatorPortNumber=%v", index, targetPortal.Address, int32(targetPortal.InitiatorPortNumber))
 		}
 	}
 

--- a/windows/iscsidsc/report_iscsi_send_target_portals_ex.go
+++ b/windows/iscsidsc/report_iscsi_send_target_portals_ex.go
@@ -15,8 +15,8 @@ import (
 // ReportIScsiSendTargetPortalsEx - Go wrapped Win32 API - ReportIScsiSendTargetPortalsExW()
 // https://docs.microsoft.com/en-us/windows/desktop/api/iscsidsc/nf-iscsidsc-reportiscsisendtargetportalsexw
 func ReportIScsiSendTargetPortalsEx() (targetPortals []*ISCSI_TARGET_PORTAL_INFO_EX, err error) {
-	log.Info(">>>>> ReportIScsiSendTargetPortalsEx")
-	defer log.Info("<<<<< ReportIScsiSendTargetPortalsEx")
+	log.Trace(">>>>> ReportIScsiSendTargetPortalsEx")
+	defer log.Trace("<<<<< ReportIScsiSendTargetPortalsEx")
 
 	// Determine the target portal count on this host
 	var portalCount, portalInfoSize uint32
@@ -45,7 +45,7 @@ func ReportIScsiSendTargetPortalsEx() (targetPortals []*ISCSI_TARGET_PORTAL_INFO
 	} else {
 		// Log the enumerated target portals
 		for index, targetPortal := range targetPortals {
-			log.Infof("targetPortals[%v], Address=%v, InitiatorPortNumber=%v", index, targetPortal.Address, int32(targetPortal.InitiatorPortNumber))
+			log.Tracef("targetPortals[%v], Address=%v, InitiatorPortNumber=%v", index, targetPortal.Address, int32(targetPortal.InitiatorPortNumber))
 		}
 	}
 

--- a/windows/iscsidsc/report_iscsi_target_portals.go
+++ b/windows/iscsidsc/report_iscsi_target_portals.go
@@ -16,8 +16,8 @@ import (
 // ReportIScsiTargetPortals - Go wrapped Win32 API - ReportIScsiTargetPortalsW()
 // https://docs.microsoft.com/en-us/windows/desktop/api/iscsidsc/nf-iscsidsc-reportiscsitargetportalsw
 func ReportIScsiTargetPortals(initiatorName string, targetName string, ipv4Only bool) (targetPortals []*ISCSI_TARGET_PORTAL, err error) {
-	log.Infof(">>>>> ReportIScsiTargetPortals, initiatorName=%v, targetName=%v, ipv4Only=%v", initiatorName, targetName, ipv4Only)
-	defer log.Info("<<<<< ReportIScsiTargetPortals")
+	log.Tracef(">>>>> ReportIScsiTargetPortals, initiatorName=%v, targetName=%v, ipv4Only=%v", initiatorName, targetName, ipv4Only)
+	defer log.Trace("<<<<< ReportIScsiTargetPortals")
 
 	// Get UTF16 versions of initiatorName and targetName
 	initiatorNameUTF16 := syscall.StringToUTF16(initiatorName)
@@ -58,7 +58,7 @@ func ReportIScsiTargetPortals(initiatorName string, targetName string, ipv4Only 
 	} else {
 		// Log the enumerated target portals
 		for index, targetPortal := range targetPortals {
-			log.Infof("targetPortals[%v], Address=%v, Socket=%v", index, targetPortal.Address, targetPortal.Socket)
+			log.Tracef("targetPortals[%v], Address=%v, Socket=%v", index, targetPortal.Address, targetPortal.Socket)
 		}
 	}
 

--- a/windows/iscsidsc/report_iscsi_targets.go
+++ b/windows/iscsidsc/report_iscsi_targets.go
@@ -16,8 +16,8 @@ import (
 // ReportIscsiTargets - Go wrapped Win32 API - ReportIscsiTargets()
 // https://docs.microsoft.com/en-us/windows/desktop/api/iscsidsc/nf-iscsidsc-reportiscsitargetsw
 func ReportIscsiTargets(forceUpdate bool) (targets []string, err error) {
-	log.Infof(">>>>> ReportIscsiTargets, forceUpdate=%v", forceUpdate)
-	defer log.Info("<<<<< ReportIscsiTargets")
+	log.Tracef(">>>>> ReportIscsiTargets, forceUpdate=%v", forceUpdate)
+	defer log.Trace("<<<<< ReportIscsiTargets")
 
 	//
 	// Note that the algorithm employed below is ported from C# ReportTargetIqns() including
@@ -98,7 +98,7 @@ func ReportIscsiTargets(forceUpdate bool) (targets []string, err error) {
 	} else {
 		// Log the enumerated targets
 		for index, target := range targets {
-			log.Infof("targets[%v]=%v", index, target)
+			log.Tracef("targets[%v]=%v", index, target)
 		}
 	}
 

--- a/windows/iscsidsc/send_scsi_inquiry.go
+++ b/windows/iscsidsc/send_scsi_inquiry.go
@@ -15,7 +15,7 @@ import (
 // SendScsiInquiry - Go wrapped Win32 API - SendScsiInquiry()
 // https://docs.microsoft.com/en-us/windows/desktop/api/iscsidsc/nf-iscsidsc-sendscsiinquiry
 func SendScsiInquiry(sessionID ISCSI_UNIQUE_SESSION_ID, lun uint64, evpdCmddt uint8, pageCode uint8) (scsiStatus uint8, inquiryBuffer []uint8, senseBuffer []uint8, err error) {
-	log.Infof(">>>>> SendScsiInquiry, sessionID=%x-%x, lun=%v, evpdCmddt=%v, pageCode=%v", sessionID.AdapterUnique, sessionID.AdapterSpecific, lun, evpdCmddt, pageCode)
+	log.Tracef(">>>>> SendScsiInquiry, sessionID=%x-%x, lun=%v, evpdCmddt=%v, pageCode=%v", sessionID.AdapterUnique, sessionID.AdapterSpecific, lun, evpdCmddt, pageCode)
 
 	// Set our Inquiry and Sense buffer sizes.  We never need more than 255 bytes from any Inquiry
 	// request we make.  Rather than adding the burden to the caller to pass in an Inquiry size,
@@ -41,7 +41,7 @@ func SendScsiInquiry(sessionID ISCSI_UNIQUE_SESSION_ID, lun uint64, evpdCmddt ui
 	if scsiStatus == SCSISTAT_CHECK_CONDITION {
 		// Only return the data that the iSCSI initiator claims was returned by the target
 		senseBuffer = senseBuffer[:senseBufferSize]
-		log.Infof("Sense Data\n%v", hex.Dump(senseBuffer))
+		log.Tracef("Sense Data\n%v", hex.Dump(senseBuffer))
 	} else {
 		// Empty sense buffer if no check condition
 		senseBuffer = nil
@@ -59,11 +59,11 @@ func SendScsiInquiry(sessionID ISCSI_UNIQUE_SESSION_ID, lun uint64, evpdCmddt ui
 		inquiryBuffer = inquiryBuffer[:inquiryBufferSize]
 
 		// Log the Inquiry data
-		log.Infof("Inquiry Data\n%v", hex.Dump(inquiryBuffer))
+		log.Tracef("Inquiry Data\n%v", hex.Dump(inquiryBuffer))
 	}
 
 	// Log the SCSI status
-	log.Infof("<<<<< SendScsiInquiry, scsiStatus=%v", scsiStatus)
+	log.Tracef("<<<<< SendScsiInquiry, scsiStatus=%v", scsiStatus)
 
 	// Return SCSI status, Inquiry buffer, Sense buffer, and error
 	return scsiStatus, inquiryBuffer, senseBuffer, err

--- a/windows/powershell/disk_cmdlets.go
+++ b/windows/powershell/disk_cmdlets.go
@@ -13,8 +13,8 @@ import (
 
 // AddPartitionAccessPath wraps the Add-PartitionAccessPath cmdlet
 func AddPartitionAccessPath(accessPath string, diskNumber uint32, partitionNumber uint32) (string, int, error) {
-	log.Infof(">>>>> AddPartitionAccessPath, accessPath=%v, diskNumber=%v, partitionNumber=%v", accessPath, diskNumber, partitionNumber)
-	defer log.Info("<<<<< AddPartitionAccessPath")
+	log.Tracef(">>>>> AddPartitionAccessPath, accessPath=%v, diskNumber=%v, partitionNumber=%v", accessPath, diskNumber, partitionNumber)
+	defer log.Trace("<<<<< AddPartitionAccessPath")
 
 	arg := fmt.Sprintf("Add-PartitionAccessPath -AccessPath %v -DiskNumber %v -PartitionNumber %v", accessPath, diskNumber, partitionNumber)
 	return execCommandOutput(arg)
@@ -22,8 +22,8 @@ func AddPartitionAccessPath(accessPath string, diskNumber uint32, partitionNumbe
 
 // ClearDisk wraps the Clear-Disk cmdlet
 func ClearDisk(diskNumber int, removeData bool) (string, int, error) {
-	log.Infof(">>>>> ClearDisk, diskNumber=%v, removeData=%v", diskNumber, removeData)
-	defer log.Info("<<<<< ClearDisk")
+	log.Tracef(">>>>> ClearDisk, diskNumber=%v, removeData=%v", diskNumber, removeData)
+	defer log.Trace("<<<<< ClearDisk")
 
 	arg := fmt.Sprintf("Clear-Disk -Number %v -RemoveData:%v -Confirm:$False", diskNumber, psBoolToText(removeData))
 	return execCommandOutput(arg)
@@ -32,8 +32,8 @@ func ClearDisk(diskNumber int, removeData bool) (string, int, error) {
 // InitializeDisk wraps the Initialize-Disk cmdlet.  We only need the ability to create GPT partitions
 // which is why this routine doesn't expose the option to select the partition style.
 func InitializeDisk(path string) (string, int, error) {
-	log.Infof(">>>>> InitializeDisk, path=%v", path)
-	defer log.Info("<<<<< InitializeDisk")
+	log.Tracef(">>>>> InitializeDisk, path=%v", path)
+	defer log.Trace("<<<<< InitializeDisk")
 
 	arg := fmt.Sprintf(`Initialize-Disk -Path "%v" -PartitionStyle GPT`, path)
 	return execCommandOutput(arg)
@@ -43,8 +43,8 @@ func InitializeDisk(path string) (string, int, error) {
 // create and format a volume with the specified file system.  If no file system is passed in, we
 // default to NTFS.
 func PartitionAndFormatVolume(diskPath string, fileSystem string) (string, int, error) {
-	log.Infof(">>>>> PartitionAndFormatVolume, diskPath=%v, fileSystem=%v", diskPath, fileSystem)
-	defer log.Info("<<<<< PartitionAndFormatVolume")
+	log.Tracef(">>>>> PartitionAndFormatVolume, diskPath=%v, fileSystem=%v", diskPath, fileSystem)
+	defer log.Trace("<<<<< PartitionAndFormatVolume")
 
 	// Default to NTFS if file system not provided
 	if len(fileSystem) == 0 {
@@ -57,8 +57,8 @@ func PartitionAndFormatVolume(diskPath string, fileSystem string) (string, int, 
 
 // RemovePartitionAccessPath wraps the Remove-PartitionAccessPath cmdlet
 func RemovePartitionAccessPath(accessPath string, diskNumber uint32, partitionNumber uint32) (string, int, error) {
-	log.Infof(">>>>> RemovePartitionAccessPath, accessPath=%v, diskNumber=%v, partitionNumber=%v", accessPath, diskNumber, partitionNumber)
-	defer log.Info("<<<<< RemovePartitionAccessPath")
+	log.Tracef(">>>>> RemovePartitionAccessPath, accessPath=%v, diskNumber=%v, partitionNumber=%v", accessPath, diskNumber, partitionNumber)
+	defer log.Trace("<<<<< RemovePartitionAccessPath")
 
 	arg := fmt.Sprintf("Remove-PartitionAccessPath -AccessPath %v -DiskNumber %v -PartitionNumber %v", accessPath, diskNumber, partitionNumber)
 	return execCommandOutput(arg)
@@ -66,24 +66,24 @@ func RemovePartitionAccessPath(accessPath string, diskNumber uint32, partitionNu
 
 // SetDiskOffline wraps the Set-Disk cmdlet with the -Path and -IsOffline options
 func SetDiskOffline(path string, isOffline bool) (string, int, error) {
-	log.Infof(">>>>> SetDiskIsOffline, path=%v, isOffline=%v", path, isOffline)
-	defer log.Info("<<<<< SetDiskIsOffline")
+	log.Tracef(">>>>> SetDiskIsOffline, path=%v, isOffline=%v", path, isOffline)
+	defer log.Trace("<<<<< SetDiskIsOffline")
 
 	return execCommandOutput(fmt.Sprintf(`Set-Disk -Path "%v" -IsOffline %v`, path, psBoolToText(isOffline)))
 }
 
 // SetDiskReadOnly wraps the Set-Disk cmdlet with the -Path and -IsReadonly options
 func SetDiskReadOnly(path string, isReadonly bool) (string, int, error) {
-	log.Infof(">>>>> SetDiskReadOnly, path=%v, isReadonly=%v", path, isReadonly)
-	defer log.Info("<<<<< SetDiskReadOnly")
+	log.Tracef(">>>>> SetDiskReadOnly, path=%v, isReadonly=%v", path, isReadonly)
+	defer log.Trace("<<<<< SetDiskReadOnly")
 
 	return execCommandOutput(fmt.Sprintf(`Set-Disk -Path "%v" -IsReadonly %v`, path, psBoolToText(isReadonly)))
 }
 
 // UpdateDisk wraps the Update-Disk cmdlet with the -Path option
 func UpdateDisk(path string) (string, int, error) {
-	log.Infof(">>>>> UpdateDisk, path=%v", path)
-	defer log.Info("<<<<< UpdateDisk")
+	log.Tracef(">>>>> UpdateDisk, path=%v", path)
+	defer log.Trace("<<<<< UpdateDisk")
 
 	return execCommandOutput(fmt.Sprintf(`Update-Disk -Path "%v"`, path))
 }

--- a/windows/shlwapi/registry.go
+++ b/windows/shlwapi/registry.go
@@ -142,7 +142,7 @@ func SHGetValue(hkey uintptr, keyName string, valueName string, dst interface{})
 
 	// Return an error if the request failed (failure logged as informational only as may not be an error condition)
 	if ret != 0 {
-		log.Infof("SHGetValue, hkey=%v, registry=%v:%v, err=%v", hkey, keyName, valueName, syscall.Errno(ret))
+		log.Tracef("SHGetValue, hkey=%v, registry=%v:%v, err=%v", hkey, keyName, valueName, syscall.Errno(ret))
 		return syscall.Errno(ret)
 	}
 

--- a/windows/wmi/mscluster_resource.go
+++ b/windows/wmi/mscluster_resource.go
@@ -75,8 +75,8 @@ type MSCluster_Property_Resource_IP_Address struct {
 
 // GetClusterIPs enumerates this host's cluster IPs
 func GetClusterIPs() (clusterIPs []*MSCluster_Resource_IP_Address, err error) {
-	log.Info(">>>>> GetClusterIPs")
-	defer log.Info("<<<<< GetClusterIPs")
+	log.Trace(">>>>> GetClusterIPs")
+	defer log.Trace("<<<<< GetClusterIPs")
 
 	// Form the WMI query
 	wmiQuery := `SELECT * FROM MSCluster_Resource WHERE Type="IP Address"`
@@ -88,7 +88,7 @@ func GetClusterIPs() (clusterIPs []*MSCluster_Resource_IP_Address, err error) {
 	if err == nil {
 		for _, clusterIP := range clusterIPs {
 			if clusterIP.PrivateProperties != nil {
-				log.Infof("Cluster IP address detected, %v", clusterIP.PrivateProperties.Address)
+				log.Tracef("Cluster IP address detected, %v", clusterIP.PrivateProperties.Address)
 			}
 		}
 	}

--- a/windows/wmi/msft_disk.go
+++ b/windows/wmi/msft_disk.go
@@ -85,8 +85,8 @@ type MSFT_Disk struct {
 
 // GetMSFTDisk enumerates this host's MSFT_Disk objects
 func GetMSFTDisk(whereOperator string) (diskDevices []*MSFT_Disk, err error) {
-	log.Infof(">>>>> GetMSFTDisk, whereOperator=%v", whereOperator)
-	defer log.Info("<<<<< GetMSFTDisk")
+	log.Tracef(">>>>> GetMSFTDisk, whereOperator=%v", whereOperator)
+	defer log.Trace("<<<<< GetMSFTDisk")
 
 	// Form the WMI query
 	wmiQuery := "SELECT * FROM MSFT_Disk"

--- a/windows/wmi/msft_fibreporthbaattributes.go
+++ b/windows/wmi/msft_fibreporthbaattributes.go
@@ -37,8 +37,8 @@ type MSFC_HBAPortAttributesResults struct {
 
 // GetMSFC_FibrePortHBAAttributes enumerates this host's MSFC_FibrePortHBAAttributes objects
 func GetMSFC_FibrePortHBAAttributes() (fcPorts []*MSFC_FibrePortHBAAttributes, err error) {
-	log.Info(">>>>> GetMSFC_FibrePortHBAAttributes")
-	defer log.Info("<<<<< GetMSFC_FibrePortHBAAttributes")
+	log.Trace(">>>>> GetMSFC_FibrePortHBAAttributes")
+	defer log.Trace("<<<<< GetMSFC_FibrePortHBAAttributes")
 
 	// Execute the WMI query
 	err = ExecQuery("SELECT * FROM MSFC_FibrePortHBAAttributes", rootWMI, &fcPorts)

--- a/windows/wmi/msft_iscsitargetportal.go
+++ b/windows/wmi/msft_iscsitargetportal.go
@@ -21,8 +21,8 @@ type MSFT_iSCSITargetPortal struct {
 
 // GetMSFTiSCSITargetPortal enumerates this host's MSFT_iSCSITargetPortal objects
 func GetMSFTiSCSITargetPortal(whereOperator string) (portals []*MSFT_iSCSITargetPortal, err error) {
-	log.Infof(">>>>> GetMSFTiSCSITargetPortal, whereOperator=%v", whereOperator)
-	log.Info("<<<<< GetMSFTiSCSITargetPortal")
+	log.Tracef(">>>>> GetMSFTiSCSITargetPortal, whereOperator=%v", whereOperator)
+	log.Trace("<<<<< GetMSFTiSCSITargetPortal")
 
 	// Form the WMI query
 	wmiQuery := "SELECT * FROM MSFT_iSCSITargetPortal"

--- a/windows/wmi/msft_partition.go
+++ b/windows/wmi/msft_partition.go
@@ -47,8 +47,8 @@ type MSFT_Partition struct {
 
 // GetMSFTPartition enumerates this host's MSFTPartition objects
 func GetMSFTPartition(whereOperator string) (diskPartitions []*MSFT_Partition, err error) {
-	log.Infof(">>>>> GetMSFTPartition, whereOperator=%v", whereOperator)
-	defer log.Info("<<<<< GetMSFTPartition")
+	log.Tracef(">>>>> GetMSFTPartition, whereOperator=%v", whereOperator)
+	defer log.Trace("<<<<< GetMSFTPartition")
 
 	// Form the WMI query
 	wmiQuery := "SELECT * FROM MSFT_Partition"

--- a/windows/wmi/msft_storagesetting.go
+++ b/windows/wmi/msft_storagesetting.go
@@ -12,14 +12,14 @@ import (
 // RescanDisks calls the UpdateHostStorageCache method of the MSFT_StorageSetting WMI class.
 // It's equivalent to performing a rescan within diskpart.exe.
 func RescanDisks() error {
-	log.Info(">>>>> RescanDisks")
-	defer log.Info("<<<<< RescanDisks")
+	log.Trace(">>>>> RescanDisks")
+	defer log.Trace("<<<<< RescanDisks")
 
 	results, err := ExecWmiMethod("MSFT_StorageSetting", "UpdateHostStorageCache", rootMicrosoftWindowsStorage)
 
 	if results != nil {
 		// Log the RescanDisks result
-		log.Infof("RescanDisks status = %v", results.Value())
+		log.Tracef("RescanDisks status = %v", results.Value())
 
 		// Release the VARIANT
 		results.Clear()

--- a/windows/wmi/msiscsi_initiatortargetclass.go
+++ b/windows/wmi/msiscsi_initiatortargetclass.go
@@ -69,8 +69,8 @@ type MSIscsiInitiator_TargetLoginOptions struct {
 
 // GetMSIscsiInitiatorTargetClass enumerates this host's MSiSCSIInitiator_TargetClass objects
 func GetMSIscsiInitiatorTargetClass(whereOperator string) (targets []*MSiSCSIInitiator_TargetClass, err error) {
-	log.Info(">>>>> GetMSIscsiInitiatorTargetClass")
-	defer log.Info("<<<<< GetMSIscsiInitiatorTargetClass")
+	log.Trace(">>>>> GetMSIscsiInitiatorTargetClass")
+	defer log.Trace("<<<<< GetMSIscsiInitiatorTargetClass")
 
 	// Form the WMI query
 	wmiQuery := "SELECT * FROM MSiSCSIInitiator_TargetClass"
@@ -85,8 +85,8 @@ func GetMSIscsiInitiatorTargetClass(whereOperator string) (targets []*MSiSCSIIni
 
 // GetMSIscsiInitiatorTargetClassForTarget enumerates the specific target's MSiSCSIInitiator_TargetClass object.
 func GetMSIscsiInitiatorTargetClassForTarget(target string) ([]*MSiSCSIInitiator_TargetClass, error) {
-	log.Infof(">>>>> GetMSIscsiInitiatorTargetClass, target=%v", target)
-	defer log.Info("<<<<< GetMSIscsiInitiatorTargetClass")
+	log.Tracef(">>>>> GetMSIscsiInitiatorTargetClass, target=%v", target)
+	defer log.Trace("<<<<< GetMSIscsiInitiatorTargetClass")
 
 	whereOperator := `TargetName = "` + target + `"`
 	return GetMSIscsiInitiatorTargetClass(whereOperator)

--- a/windows/wmi/msiscsi_portalinfoclass.go
+++ b/windows/wmi/msiscsi_portalinfoclass.go
@@ -47,8 +47,8 @@ type MSiSCSI_PortalInfoClass struct {
 
 // GetMSiSCSIPortalInfoClass enumerates this host's MSiSCSI_PortalInfoClass object
 func GetMSiSCSIPortalInfoClass() (portals *MSiSCSI_PortalInfoClass, err error) {
-	log.Info(">>>>> GetMSiSCSIPortalInfoClass")
-	defer log.Info("<<<<< GetMSiSCSIPortalInfoClass")
+	log.Trace(">>>>> GetMSiSCSIPortalInfoClass")
+	defer log.Trace("<<<<< GetMSiSCSIPortalInfoClass")
 
 	// Execute the WMI query
 	err = ExecQuery("SELECT * FROM MSiSCSI_PortalInfoClass", rootWMI, &portals)

--- a/windows/wmi/win32_diskdrive.go
+++ b/windows/wmi/win32_diskdrive.go
@@ -67,8 +67,8 @@ type Win32_DiskDrive struct {
 
 // GetWin32DiskDrive enumerates this host's Win32_DiskDrive objects
 func GetWin32DiskDrive(whereOperator string) (diskDevices []*Win32_DiskDrive, err error) {
-	log.Infof(">>>>> GetWin32DiskDrive, whereOperator=%v", whereOperator)
-	defer log.Info("<<<<< GetWin32DiskDrive")
+	log.Tracef(">>>>> GetWin32DiskDrive, whereOperator=%v", whereOperator)
+	defer log.Trace("<<<<< GetWin32DiskDrive")
 
 	// Form the WMI query
 	wmiQuery := "SELECT * FROM Win32_DiskDrive"
@@ -87,7 +87,7 @@ func GetWin32DiskDrive(whereOperator string) (diskDevices []*Win32_DiskDrive, er
 		if diskDevice.Index != ^uint32(0) {
 			capacity, _ := ioctl.GetDiskCapacity(diskDevice.Index)
 			if capacity > diskDevice.Size {
-				log.Infof("Adjusting disk capacity from %v to true size of %v", diskDevice.Size, capacity)
+				log.Tracef("Adjusting disk capacity from %v to true size of %v", diskDevice.Size, capacity)
 				diskDevice.Size = capacity
 			}
 		}

--- a/windows/wmi/win32_diskpartition.go
+++ b/windows/wmi/win32_diskpartition.go
@@ -51,8 +51,8 @@ type Win32_DiskPartition struct {
 
 // GetWin32DiskPartition enumerates this host's Win32_DiskPartition objects
 func GetWin32DiskPartition(whereOperator string) (diskPartitions []*Win32_DiskPartition, err error) {
-	log.Infof(">>>>> GetWin32DiskPartition, whereOperator=%v", whereOperator)
-	defer log.Info("<<<<< GetWin32DiskPartition")
+	log.Tracef(">>>>> GetWin32DiskPartition, whereOperator=%v", whereOperator)
+	defer log.Trace("<<<<< GetWin32DiskPartition")
 
 	// Form the WMI query
 	wmiQuery := "SELECT * FROM Win32_DiskPartition"

--- a/windows/wmi/win32_operatingsystem.go
+++ b/windows/wmi/win32_operatingsystem.go
@@ -79,8 +79,8 @@ type Win32_OperatingSystem struct {
 
 // GetWin32OperatingSystem enumerates this host's Win32_OperatingSystem object
 func GetWin32OperatingSystem() (operatingSystem *Win32_OperatingSystem, err error) {
-	log.Info(">>>>> GetWin32OperatingSystem")
-	defer log.Info("<<<<< GetWin32OperatingSystem")
+	log.Trace(">>>>> GetWin32OperatingSystem")
+	defer log.Trace("<<<<< GetWin32OperatingSystem")
 
 	// Execute the WMI query
 	err = ExecQuery("SELECT * FROM Win32_OperatingSystem", rootCIMV2, &operatingSystem)

--- a/windows/wmi/win32_volume.go
+++ b/windows/wmi/win32_volume.go
@@ -59,8 +59,8 @@ type Win32_Volume struct {
 
 // GetWin32Volume enumerates this host's Win32_Volume objects
 func GetWin32Volume() (volumes []*Win32_Volume, err error) {
-	log.Infof(">>>>> GetWin32Volume")
-	defer log.Info("<<<<< GetWin32Volume")
+	log.Tracef(">>>>> GetWin32Volume")
+	defer log.Trace("<<<<< GetWin32Volume")
 
 	// Execute the WMI query
 	err = ExecQuery("SELECT * FROM Win32_Volume", rootCIMV2, &volumes)

--- a/windows/wmi/wmimethod.go
+++ b/windows/wmi/wmimethod.go
@@ -15,8 +15,8 @@ import (
 // ExecWmiMethod is used to execute a WMI method.  A VARIANT is returned from the WMI method as well
 // as an error should the WMI method be executed.
 func ExecWmiMethod(className, methodName, namespace string, params ...interface{}) (result *ole.VARIANT, err error) {
-	log.Infof(">>>>> ExecWmiMethod, className=%v, methodName=%v, namespace=%v", className, methodName, namespace)
-	defer log.Info("<<<<< ExecWmiMethod")
+	log.Tracef(">>>>> ExecWmiMethod, className=%v, methodName=%v, namespace=%v", className, methodName, namespace)
+	defer log.Trace("<<<<< ExecWmiMethod")
 
 	// Only support one WMI query at a time
 	lock.Lock()

--- a/windows/wmi/wmiquery.go
+++ b/windows/wmi/wmiquery.go
@@ -476,8 +476,8 @@ func Cleanup() {
 // ExecQuery executes the given WMI query, in the given namespace, and returns JSON objects
 func ExecQuery(wqlQuery string, namespace string, dst interface{}) (err error) {
 
-	log.Infof(">>>>> ExecQuery, wqlQuery=%v, namespace=%v", wqlQuery, namespace)
-	defer log.Info("<<<<< ExecQuery")
+	log.Tracef(">>>>> ExecQuery, wqlQuery=%v, namespace=%v", wqlQuery, namespace)
+	defer log.Trace("<<<<< ExecQuery")
 
 	// If our package init routine was unable to initialize COM, immediately fail the request
 	if wmiWbemLocator == nil {
@@ -514,7 +514,7 @@ func ExecQuery(wqlQuery string, namespace string, dst interface{}) (err error) {
 	}
 
 	// Log details about the destination object
-	log.Infof("Destination object, dstType=%v, dstPath=%v, isSlicePtr=%v", dstType.Name(), dstPath, isSlicePtr)
+	log.Tracef("Destination object, dstType=%v, dstPath=%v, isSlicePtr=%v", dstType.Name(), dstPath, isSlicePtr)
 
 	// How we execute WMI queries from Go is modeled from Microsoft's sample C++ code
 	// https://docs.microsoft.com/en-us/windows/desktop/wmisdk/example--getting-wmi-data-from-the-local-computer
@@ -556,7 +556,7 @@ func ExecQuery(wqlQuery string, namespace string, dst interface{}) (err error) {
 		// If WMI namespace isn't present on this host, we don't consider that an error and log the
 		// result as informational, else it's logged as an error.
 		if hres == WBEM_E_INVALID_NAMESPACE {
-			log.Info(msg)
+			log.Trace(msg)
 		} else {
 			log.Error(msg)
 		}
@@ -615,7 +615,7 @@ func ExecQuery(wqlQuery string, namespace string, dst interface{}) (err error) {
 		}
 
 		// Log the number of WMI classes enumerated thus far
-		log.Infof("Enumerating WMI class object %v", itemCount)
+		log.Tracef("Enumerating WMI class object %v", itemCount)
 
 		// Allocate a new Go object for the WMI class and then unmarshall the WMI class into the Go object
 		dstObject := reflect.New(dstType)
@@ -689,8 +689,6 @@ func getInterfaceType(dst interface{}) (dstPath string, dstType reflect.Type) {
 // of the caller to pass in a pointer to the Go object in order for this routine to populate
 // the object accordingly.
 func wmiClassToGoObject(wmiClass *ole.IUnknown, goObject interface{}, classProperty string) (err error) {
-	log.Infof(">>>>> wmiClassToGoObject, classProperty=%v", classProperty)
-	defer log.Info("<<<<< wmiClassToGoObject")
 
 	// Traverse the Go object to build up a key/value map of its fields
 	fieldMap, err := interfaceToFieldMap(goObject)
@@ -720,7 +718,7 @@ func wmiClassToGoObject(wmiClass *ole.IUnknown, goObject interface{}, classPrope
 
 	// Convert the WMI class name to text and log results
 	className := syscall.UTF16ToString((*[1024]uint16)(unsafe.Pointer(uintptr(vtProp.Val)))[:])
-	log.Infof("Enumerated WMI class name, __CLASS=%v", className)
+	log.Tracef("Enumerated WMI class name, __CLASS=%v", className)
 	ole.VariantClear(&vtProp)
 
 	// Query the WMI class property names
@@ -768,7 +766,7 @@ func wmiClassToGoObject(wmiClass *ole.IUnknown, goObject interface{}, classPrope
 				f := goObjectValue.Field(v.index)
 				f.Set(reflect.ValueOf(v.nilValue))
 			}
-			log.Infof(`Field "%v" defined in Go object but not supported by WMI on this host, nilValue=%v`, k, v.nilValue)
+			log.Tracef(`Field "%v" defined in Go object but not supported by WMI on this host, nilValue=%v`, k, v.nilValue)
 		}
 	}
 
@@ -780,7 +778,7 @@ func wmiClassToGoObject(wmiClass *ole.IUnknown, goObject interface{}, classPrope
 		if !ok {
 			// If there is no Go field definition, for the enumerated WMI property, log as informational
 			// so that we can add the property to the Go definition.
-			log.Infof(`Property "%v" returned by WMI but not defined in Go object`, classProperty)
+			log.Tracef(`Property "%v" returned by WMI but not defined in Go object`, classProperty)
 			continue
 		}
 


### PR DESCRIPTION
* Problem:
  * Many CHAPI2 log.Info* messages should be log.Trace*
* Implementation:
  * Transition log.Info* to log.Trace* where applicable
  * Removed unnecessary "mikeb" from chapi.go comment
  * Eliminate wmiClassToGoObject entry/exit logging (unnecessary; too many trace log events)
  * Primary focus on Windows base libraries (plus a few other packages)
  * Additional package updates will come in the near future
* Testing:
  * Built on Windows and Linux
* Reviewers:
  * @shivamerla 
* Bug: N/A