### PR TITLE
chapi2:  Add DeleteDevice endpoint for Windows plus logging improvements

### DIFF
--- a/chapi2/chapi_windows.go
+++ b/chapi2/chapi_windows.go
@@ -55,8 +55,8 @@ func Run() (err error) {
 // This function will invoke a new chapid listener with socket filename containing current process ID
 // NOTE: invoke this function as go routine as it will block on socket listener
 func startChapid(result chan error) {
-	log.Info(">>>>> startChapid")
-	defer log.Info("<<<<< startChapid")
+	log.Trace(">>>>> startChapid")
+	defer log.Trace("<<<<< startChapid")
 
 	var err error
 	// create Listener object
@@ -79,7 +79,7 @@ func startChapid(result chan error) {
 			result <- nil
 			err = http.Serve(chapidListener, router)
 			if err != nil {
-				log.Infof("exiting chapid server, err=%v", err.Error())
+				log.Tracef("exiting chapid server, err=%v", err.Error())
 			}
 
 			// Remove our CHAPI port and key files now that CHAPI has exited
@@ -93,8 +93,8 @@ func startChapid(result chan error) {
 
 // StopChapid will stop the given http listener
 func StopChapid() error {
-	log.Info(">>>>> StopChapid")
-	defer log.Info("<<<<< StopChapid")
+	log.Trace(">>>>> StopChapid")
+	defer log.Trace("<<<<< StopChapid")
 
 	// Block any new CHAPI creation request while we're in the middle of trying to close
 	// out any existing CHAPI server.

--- a/chapi2/driver/driver.go
+++ b/chapi2/driver/driver.go
@@ -3,6 +3,8 @@
 package driver
 
 import (
+	"fmt"
+
 	"github.com/hpe-storage/common-host-libs/chapi2/cerrors"
 	"github.com/hpe-storage/common-host-libs/chapi2/fc"
 	"github.com/hpe-storage/common-host-libs/chapi2/host"
@@ -26,6 +28,7 @@ const (
 	errorMessageNoNetworkInterfaces   = "no network interfaces found on host"
 	errorMessageNoPartitionsOnVolume  = "no partitions found on volume"
 	errorMessageNotYetImplemented     = "not yet implemented"
+	errorMessageVolumeMounted         = "volume mounted"
 )
 
 // Driver provides a common interface for host related operations
@@ -103,25 +106,32 @@ func (driver *ChapiServer) GetHostInfo() (*model.Host, error) {
 	defer log.Trace("<<<<< GetHostInfo")
 	hostPlugin := host.NewHostPlugin()
 
+	log.Info("Get Host Information")
+
 	id, err := hostPlugin.GetUuid()
 	if err != nil {
 		return nil, cerrors.NewChapiError(err)
 	}
+	log.Infof("Host UUID - %v", id)
 
 	hostName, err := hostPlugin.GetHostName()
 	if err != nil {
 		return nil, cerrors.NewChapiError(err)
 	}
+	log.Infof("Host Name - %v", hostName)
 
 	domainName, err := hostPlugin.GetDomainName()
 	if err != nil {
 		return nil, cerrors.NewChapiError(err)
 	}
+	log.Infof("Domain Name - %v", domainName)
 
 	networks, err := hostPlugin.GetNetworks()
 	if err != nil {
 		return nil, cerrors.NewChapiError(err)
 	}
+	driver.logNetworks(networks)
+
 	return &model.Host{UUID: id, Name: hostName, Domain: domainName, Networks: networks}, nil
 }
 
@@ -131,6 +141,8 @@ func (driver *ChapiServer) GetHostNetworks() ([]*model.Network, error) {
 	defer log.Trace("<<<<< GetHostNetworks")
 	hostPlugin := host.NewHostPlugin()
 
+	log.Info("Get Host Networks")
+
 	networks, err := hostPlugin.GetNetworks()
 	if err != nil {
 		return nil, cerrors.NewChapiError(err)
@@ -138,6 +150,7 @@ func (driver *ChapiServer) GetHostNetworks() ([]*model.Network, error) {
 	if len(networks) == 0 {
 		return nil, cerrors.NewChapiError(cerrors.NotFound, errorMessageNoNetworkInterfaces)
 	}
+	driver.logNetworks(networks)
 	return networks, nil
 }
 
@@ -147,6 +160,8 @@ func (driver *ChapiServer) GetHostInitiators() ([]*model.Initiator, error) {
 	defer log.Trace("<<<<< GetHostInitiators")
 	//var inits Initiators
 	var inits []*model.Initiator
+
+	log.Info("Get Host Initiators")
 
 	// fetch iscsi initiator details
 	iscsiPlugin := iscsi.NewIscsiPlugin()
@@ -174,7 +189,13 @@ func (driver *ChapiServer) GetHostInitiators() ([]*model.Initiator, error) {
 		return nil, cerrors.NewChapiError(cerrors.NotFound, errorMessageNoInitiatorsFound)
 	}
 
-	log.Trace("initiators ", inits)
+	// Log enumerated iSCSI and FC initiators
+	for _, initiator := range inits {
+		for _, init := range initiator.Init {
+			log.Infof("AccessProtocol=%v, Initiator=%v", initiator.AccessProtocol, init)
+		}
+	}
+
 	return inits, nil
 }
 
@@ -185,9 +206,11 @@ func (driver *ChapiServer) GetHostInitiators() ([]*model.Initiator, error) {
 // GetDevices enumerates all the Nimble volumes with basic details.
 // If serialNumber is non-empty then only specified device is returned
 func (driver *ChapiServer) GetDevices(serialNumber string) ([]*model.Device, error) {
-	log.Trace(">>>>> GetDevices called")
+	log.Tracef(">>>>> GetDevices called, serialNumber=%v", serialNumber)
 	defer log.Trace("<<<<< GetDevices")
 	multipathPlugin := multipath.NewMultipathPlugin()
+
+	log.Infof("Get Devices, serialNumber=%v", serialNumber)
 
 	// Enumerate all the Nimble volumes on this host (basic details only)
 	devices, err := multipathPlugin.GetDevices(serialNumber)
@@ -200,6 +223,11 @@ func (driver *ChapiServer) GetDevices(serialNumber string) ([]*model.Device, err
 		return nil, cerrors.NewChapiError(cerrors.NotFound, errorMessageNoDevicesOnHost)
 	}
 
+	// Log enumerated device serial numbers
+	for _, device := range devices {
+		log.Infof("Device SerialNumber=%v", device.SerialNumber)
+	}
+
 	return devices, nil
 }
 
@@ -209,6 +237,8 @@ func (driver *ChapiServer) GetAllDeviceDetails(serialNumber string) ([]*model.De
 	log.Tracef(">>>>> GetAllDeviceDetails called, serialNumber=%v", serialNumber)
 	defer log.Trace("<<<<< GetAllDeviceDetails")
 	multipathPlugin := multipath.NewMultipathPlugin()
+
+	log.Infof("Get All Device Details, serialNumber=%v", serialNumber)
 
 	// Enumerate all the Nimble volumes on this host (full details)
 	devices, err := multipathPlugin.GetAllDeviceDetails(serialNumber)
@@ -221,6 +251,9 @@ func (driver *ChapiServer) GetAllDeviceDetails(serialNumber string) ([]*model.De
 		return nil, cerrors.NewChapiError(cerrors.NotFound, errorMessageNoDevicesOnHost)
 	}
 
+	// Log enumerated device details
+	driver.logDeviceArrayDetails(devices)
+
 	return devices, nil
 }
 
@@ -229,6 +262,8 @@ func (driver *ChapiServer) GetPartitionInfo(serialNumber string) ([]*model.Devic
 	log.Tracef(">>>>> GetPartitionInfo called, serialNumber=%v", serialNumber)
 	defer log.Trace("<<<<< GetPartitionInfo")
 	multipathPlugin := multipath.NewMultipathPlugin()
+
+	log.Infof("Get Partition Information, serialNumber=%v", serialNumber)
 
 	// Enumerate all the Nimble volume's partition
 	partitions, err := multipathPlugin.GetPartitionInfo(serialNumber)
@@ -241,6 +276,11 @@ func (driver *ChapiServer) GetPartitionInfo(serialNumber string) ([]*model.Devic
 		return nil, cerrors.NewChapiError(cerrors.NotFound, errorMessageNoPartitionsOnVolume)
 	}
 
+	// Log enumerated partition details
+	for _, partition := range partitions {
+		log.Infof("Partition Name=%v, PartitionType=%v, Size=%v", partition.Name, partition.PartitionType, partition.Size)
+	}
+
 	return partitions, nil
 }
 
@@ -248,6 +288,8 @@ func (driver *ChapiServer) GetPartitionInfo(serialNumber string) ([]*model.Devic
 func (driver *ChapiServer) CreateDevice(publishInfo model.PublishInfo) (*model.Device, error) {
 	log.Tracef(">>>>> CreateDevice called, publishInfo=%v", publishInfo)
 	defer log.Trace("<<<<< CreateDevice")
+
+	log.Info("Create Device")
 
 	// Invalid request if no device access object provided
 	if (publishInfo.BlockDev == nil) && (publishInfo.VirtualDev == nil) {
@@ -272,15 +314,52 @@ func (driver *ChapiServer) CreateDevice(publishInfo model.PublishInfo) (*model.D
 
 	// Attach the block device
 	multipathPlugin := multipath.NewMultipathPlugin()
-	return multipathPlugin.AttachDevice(publishInfo.SerialNumber, *publishInfo.BlockDev)
+	device, err := multipathPlugin.AttachDevice(publishInfo.SerialNumber, *publishInfo.BlockDev)
+	if err != nil {
+		return nil, err
+	}
+
+	driver.logDeviceDetails(device)
+	return device, nil
 }
 
 // DeleteDevice will delete the given device from the host
 func (driver *ChapiServer) DeleteDevice(serialNumber string) error {
 	log.Tracef(">>>>> DeleteDevice called, serialNumber=%v", serialNumber)
 	defer log.Trace("<<<<< DeleteDevice")
+	multipathPlugin := multipath.NewMultipathPlugin()
 
-	return cerrors.NewChapiError(cerrors.Unimplemented, errorMessageNotYetImplemented)
+	log.Infof("Delete Device, serialNumber=%v", serialNumber)
+
+	// TODO - handle VirtualDev vs BlockDev
+
+	// Find the device serial number details.  If the device is not present on this host (i.e.
+	// cerrors.NotFound), there is no device to detach so we return no error.
+	devices, err := multipathPlugin.GetAllDeviceDetails(serialNumber)
+	if len(devices) == 0 {
+		log.Infof("Serial number %v not present, returning success", serialNumber)
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	// Fail request if device is mounted.  We only allow deleting the device if it isn't already
+	// mounted.  Caller should dismount the device before attempting to delete the device.
+	if mounts, _ := driver.GetMounts(serialNumber); len(mounts) > 0 {
+		err = cerrors.NewChapiError(cerrors.PermissionDenied, errorMessageVolumeMounted)
+		log.Error(err)
+		return err
+	}
+
+	// Detach the block device
+	driver.logDeviceDetails(devices[0])
+	if err := multipathPlugin.DetachDevice(*devices[0]); err != nil {
+		return err
+	}
+
+	// Success!!!
+	log.Infof("Device Deleted, SerialNumber=%v", serialNumber)
+	return nil
 }
 
 // OfflineDevice will offline the given device from the host
@@ -289,6 +368,8 @@ func (driver *ChapiServer) OfflineDevice(serialNumber string) error {
 	defer log.Trace("<<<<< OfflineDevice")
 	multipathPlugin := multipath.NewMultipathPlugin()
 
+	log.Infof("Offline Device, serialNumber=%v", serialNumber)
+
 	// Enumerate basic details for the serial number
 	device, err := driver.getSingleDeviceSummary(serialNumber)
 	if err != nil {
@@ -296,7 +377,13 @@ func (driver *ChapiServer) OfflineDevice(serialNumber string) error {
 	}
 
 	// Offline the device
-	return multipathPlugin.OfflineDevice(*device)
+	if err := multipathPlugin.OfflineDevice(*device); err != nil {
+		return err
+	}
+
+	// Success!!!
+	log.Infof("Device Offlined, SerialNumber=%v", serialNumber)
+	return nil
 }
 
 // CreateFileSystem writes the given file system to the device with the given serial number
@@ -305,6 +392,8 @@ func (driver *ChapiServer) CreateFileSystem(serialNumber string, filesystem stri
 	defer log.Trace("<<<<< CreateFileSystem")
 	multipathPlugin := multipath.NewMultipathPlugin()
 
+	log.Infof("Create File System, serialNumber=%v, filesystem=%v", serialNumber, filesystem)
+
 	// Enumerate basic details for the serial number
 	device, err := driver.getSingleDeviceSummary(serialNumber)
 	if err != nil {
@@ -312,6 +401,7 @@ func (driver *ChapiServer) CreateFileSystem(serialNumber string, filesystem stri
 	}
 
 	// Format the device
+	driver.logDeviceDetails(device)
 	return multipathPlugin.CreateFileSystem(*device, filesystem)
 }
 
@@ -323,6 +413,8 @@ func (driver *ChapiServer) CreateFileSystem(serialNumber string, filesystem stri
 func (driver *ChapiServer) GetMounts(serialNumber string) ([]*model.Mount, error) {
 	log.Tracef(">>>>> GetMounts called, serialNumber=%v", serialNumber)
 	defer log.Trace("<<<<< GetMounts")
+
+	log.Infof("Get Mounts, serialNumber=%v", serialNumber)
 
 	// Route request to the mount package to get the mounts
 	mountPlugin := mount.NewMounter()
@@ -336,6 +428,7 @@ func (driver *ChapiServer) GetMounts(serialNumber string) ([]*model.Mount, error
 		return nil, cerrors.NewChapiError(cerrors.NotFound, errorMessageNoMountPointsFound)
 	}
 
+	driver.logMountArray(mounts)
 	return mounts, nil
 }
 
@@ -343,6 +436,8 @@ func (driver *ChapiServer) GetMounts(serialNumber string) ([]*model.Mount, error
 func (driver *ChapiServer) GetAllMountDetails(serialNumber string, mountId string) ([]*model.Mount, error) {
 	log.Tracef(">>>>> GetMount called, serialNumber=%v, mountPointID=%v", serialNumber, mountId)
 	defer log.Trace("<<<<< GetMount")
+
+	log.Infof("Get All Mount Details, serialNumber=%v, mountId=%v", serialNumber, mountId)
 
 	// Route request to the mount package to get the mounts
 	mountPlugin := mount.NewMounter()
@@ -356,13 +451,16 @@ func (driver *ChapiServer) GetAllMountDetails(serialNumber string, mountId strin
 		return nil, cerrors.NewChapiError(cerrors.NotFound, errorMessageNoMountPointsFound)
 	}
 
+	driver.logMountArray(mounts)
 	return mounts, nil
 }
 
 // CreateMount mounts the given device to the given mount point
 func (driver *ChapiServer) CreateMount(serialNumber string, mountPoint string, fsOptions *model.FileSystemOptions) (*model.Mount, error) {
-	log.Tracef(">>>>> MountDevice called, serialNumber=%v, mountPoint=%v, fsOptions=%v", serialNumber, mountPoint, fsOptions)
-	defer log.Trace("<<<<< MountDevice")
+	log.Tracef(">>>>> CreateMount called, serialNumber=%v, mountPoint=%v, fsOptions=%v", serialNumber, mountPoint, fsOptions)
+	defer log.Trace("<<<<< CreateMount")
+
+	log.Infof("Create Mount, serialNumber=%v, mountPoint=%v", serialNumber, mountPoint)
 
 	// Route request to the mount package to create the mount point
 	mountPlugin := mount.NewMounter()
@@ -371,6 +469,7 @@ func (driver *ChapiServer) CreateMount(serialNumber string, mountPoint string, f
 		return nil, err
 	}
 
+	driver.logMount(mount)
 	return mount, nil
 }
 
@@ -379,15 +478,25 @@ func (driver *ChapiServer) DeleteMount(serialNumber string, mountPointId string)
 	log.Tracef(">>>>> DeleteMount called, serialNumber=%v, mountPointID=%v", serialNumber, mountPointId)
 	defer log.Trace("<<<<< DeleteMount")
 
+	log.Infof("Delete Mount, serialNumber=%v, mountPointId=%v", serialNumber, mountPointId)
+
 	// Route request to the mount package to delete the mount point
 	mountPlugin := mount.NewMounter()
-	return mountPlugin.DeleteMount(serialNumber, mountPointId)
+	if err := mountPlugin.DeleteMount(serialNumber, mountPointId); err != nil {
+		return err
+	}
+
+	// Success!!!
+	log.Infof("Mount Point ID %v successfully deleted", mountPointId)
+	return nil
 }
 
 // CreateBindMount unmounts the given mount point
 func (driver *ChapiServer) CreateBindMount(sourceMount string, targetMount string, bindType string) (*model.Mount, error) {
 	log.Tracef(">>>>> CreateBindMount called, sourceMount=%s, targetMount=%s bindType=%s", sourceMount, targetMount, bindType)
 	defer log.Trace("<<<<< CreateBindMount")
+
+	log.Infof("Create Bind Mount, sourceMount=%v, targetMount=%v, bindType=%v", sourceMount, targetMount, bindType)
 
 	return nil, cerrors.NewChapiError(cerrors.Unimplemented, errorMessageNotYetImplemented)
 }
@@ -402,11 +511,17 @@ func (driver *ChapiServer) CreateBindMount(sourceMount string, targetMount strin
 func (driver *ChapiServer) getSingleDeviceSummary(serialNumber string) (*model.Device, error) {
 	log.Tracef(">>>>> getSingleDeviceSummary called, serialNumber=%v", serialNumber)
 	defer log.Trace("<<<<< getSingleDeviceSummary")
+	multipathPlugin := multipath.NewMultipathPlugin()
 
 	// Enumerate the device details for the provided serial number
-	devices, err := driver.GetDevices(serialNumber)
+	devices, err := multipathPlugin.GetDevices(serialNumber)
 	if err != nil {
-		return nil, err
+		return nil, cerrors.NewChapiError(err)
+	}
+
+	// Fail request if no Nimble devices found on this host
+	if len(devices) == 0 {
+		return nil, cerrors.NewChapiError(cerrors.NotFound, errorMessageNoDevicesOnHost)
 	}
 
 	// If we did not enumerate a single volume, with the provided serial number, the host is likely
@@ -419,4 +534,51 @@ func (driver *ChapiServer) getSingleDeviceSummary(serialNumber string) (*model.D
 
 	// Return the single enumerated volume
 	return devices[0], nil
+}
+
+// logNetworks records the host NIC details, one line for NIC, to the information log
+func (driver *ChapiServer) logNetworks(networks []*model.Network) {
+	for _, network := range networks {
+		log.Infof("Network=%v, AddressV4=%v, MaskV4=%v, Up=%v", network.Name, network.AddressV4, network.MaskV4, network.Up)
+	}
+}
+
+// logDeviceArrayDetails records the device array details to the information log
+func (driver *ChapiServer) logDeviceArrayDetails(devices []*model.Device) {
+	for _, device := range devices {
+		driver.logDeviceDetails(device)
+	}
+}
+
+// logDeviceDetails records the device details to the information log
+func (driver *ChapiServer) logDeviceDetails(device *model.Device) {
+	if device == nil {
+		log.Error("logDeviceDetails called with nil device")
+		return
+	}
+	msg := fmt.Sprintf("Device SerialNumber=%v, Pathname=%v, Size=%v, State=%v", device.SerialNumber, device.Pathname, device.Size, device.State)
+	if device.IscsiTarget != nil {
+		msg += fmt.Sprintf(", IscsiTargetName=%v, TargetScope=%v", device.IscsiTarget.Name, device.IscsiTarget.TargetScope)
+	}
+	log.Infoln(msg)
+}
+
+// logMountArray records the mount details to the information log
+func (driver *ChapiServer) logMountArray(mounts []*model.Mount) {
+	for _, mount := range mounts {
+		driver.logMount(mount)
+	}
+}
+
+// logMount records the single mount details to the information log
+func (driver *ChapiServer) logMount(mount *model.Mount) {
+	if mount == nil {
+		log.Error("logMount called with nil mount")
+		return
+	}
+	msg := fmt.Sprintf("Mount ID=%v", mount.ID)
+	if (mount.MountPoint != "") || (mount.SerialNumber != "") {
+		msg += fmt.Sprintf(", MountPoint=%v, SerialNumber=%v", mount.MountPoint, mount.SerialNumber)
+	}
+	log.Infoln(msg)
 }

--- a/chapi2/fc/fc.go
+++ b/chapi2/fc/fc.go
@@ -24,8 +24,8 @@ func (plugin *FcPlugin) RescanAdapter(adapter string) error {
 
 // GetInitiators get all host fc initiators (port WWNs)
 func (plugin *FcPlugin) GetFcInitiators() (*model.Initiator, error) {
-	log.Info(">>>>> GetFcInitiators")
-	defer log.Info("<<<<< GetFcInitiators")
+	log.Trace(">>>>> GetFcInitiators")
+	defer log.Trace("<<<<< GetFcInitiators")
 
 	inits, err := getAllFcHostPortWwn()
 	if err != nil {
@@ -44,15 +44,15 @@ func (plugin *FcPlugin) GetFcInitiators() (*model.Initiator, error) {
 
 // GetAllFcHostPorts get all the FC host port details on the host
 func (plugin *FcPlugin) GetAllFcHostPorts() ([]*model.FcHostPort, error) {
-	log.Info(">>>>> GetAllFcHostPorts")
-	defer log.Info("<<<<< GetAllFcHostPorts")
+	log.Trace(">>>>> GetAllFcHostPorts")
+	defer log.Trace("<<<<< GetAllFcHostPorts")
 	return getAllFcHostPorts()
 }
 
 // GetAllFcHostPortWWN get all FC host port WWN's on the host
 func (plugin *FcPlugin) GetAllFcHostPortWwn() ([]string, error) {
-	log.Info(">>>>> GetAllFcHostPortWwn called")
-	defer log.Info("<<<<< GetAllFcHostPortWwn")
+	log.Trace(">>>>> GetAllFcHostPortWwn called")
+	defer log.Trace("<<<<< GetAllFcHostPortWwn")
 	hostPorts, err := getAllFcHostPorts()
 	if err != nil {
 		return nil, err
@@ -69,7 +69,7 @@ func (plugin *FcPlugin) GetAllFcHostPortWwn() ([]string, error) {
 
 // RescanFcTarget rescans host ports for new Fibre Channel devices
 func (plugin *FcPlugin) RescanFcTarget(lunID string) error {
-	log.Infof(">>>>> RescanFcTarget called with lun id %s", lunID)
-	defer log.Info("<<<<< RescanFcTarget")
+	log.Tracef(">>>>> RescanFcTarget called with lun id %s", lunID)
+	defer log.Trace("<<<<< RescanFcTarget")
 	return rescanFcTarget(lunID)
 }

--- a/chapi2/fc/fc_util.go
+++ b/chapi2/fc/fc_util.go
@@ -8,8 +8,8 @@ import (
 
 // getAllFcHostPortWwn get all FC host port WWN's on the host
 func getAllFcHostPortWwn() ([]string, error) {
-	log.Infof(">>>>> getAllFcHostPortWwn called")
-	defer log.Info("<<<<< getAllFcHostPortWwn")
+	log.Tracef(">>>>> getAllFcHostPortWwn called")
+	defer log.Trace("<<<<< getAllFcHostPortWwn")
 	hostPorts, err := getAllFcHostPorts()
 	if err != nil {
 		return nil, err

--- a/chapi2/fc/fc_windows.go
+++ b/chapi2/fc/fc_windows.go
@@ -12,8 +12,8 @@ import (
 
 // getAllFcHostPorts get all the FC host port details on the host
 func getAllFcHostPorts() (hostPorts []*model.FcHostPort, err error) {
-	log.Info(">>>>> GetAllFcHostPorts called")
-	defer log.Info("<<<<< GetAllFcHostPorts")
+	log.Trace(">>>>> GetAllFcHostPorts called")
+	defer log.Trace("<<<<< GetAllFcHostPorts")
 
 	// Enumerate the FC ports on this host
 	var fcPorts []*wmi.MSFC_FibrePortHBAAttributes

--- a/chapi2/handler/handler.go
+++ b/chapi2/handler/handler.go
@@ -311,7 +311,6 @@ func CreateFileSystem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Infof("creating filesystem of type %s on device %s", fileSystem, serialNumber)
 	err := driver.CreateFileSystem(serialNumber, fileSystem)
 	if err != nil {
 		handleError(w, chapiResp, err, http.StatusInternalServerError)

--- a/chapi2/handler/handler_windows.go
+++ b/chapi2/handler/handler_windows.go
@@ -65,6 +65,7 @@ func GetKeyfile(w http.ResponseWriter, r *http.Request) {
 	log.Tracef(">>>>> getKeyfile called, chapiKeyFilePath=%v", chapiKeyFilePath)
 	defer log.Trace("<<<<< getKeyfile")
 
+	log.Infof("CHAPI key path - %v", chapiKeyFilePath)
 	var chapiResp Response
 	chapiResp.Data = model.KeyFileInfo{Path: chapiKeyFilePath}
 	json.NewEncoder(w).Encode(chapiResp)

--- a/chapi2/iscsi/iscsi.go
+++ b/chapi2/iscsi/iscsi.go
@@ -56,8 +56,8 @@ func (plugin *IscsiPlugin) GetAllLoggedInTargets() ([]*model.IscsiTarget, error)
 }
 
 func (plugin *IscsiPlugin) GetTargetPortals(targetName string, ipv4Only bool) ([]*model.TargetPortal, error) {
-	log.Tracef(">>> GetTargetPortals, targetName=%v, ipv4Only=%v", targetName, ipv4Only)
-	defer log.Traceln("<<< GetTargetPortals")
+	log.Tracef(">>>>> GetTargetPortals, targetName=%v, ipv4Only=%v", targetName, ipv4Only)
+	defer log.Traceln("<<<<< GetTargetPortals")
 	return plugin.getTargetPortals(targetName, ipv4Only)
 }
 
@@ -73,8 +73,8 @@ func (plugin *IscsiPlugin) DiscoverTargets(portal string) ([]*model.IscsiTarget,
 
 // LoginTarget ensures that the provided iSCSI device is logged into this host
 func (plugin *IscsiPlugin) LoginTarget(blockDev model.BlockDeviceAccessInfo) (err error) {
-	log.Tracef(">>> LoginTarget, TargetName=%v", blockDev.TargetName)
-	defer log.Traceln("<<< LoginTarget")
+	log.Tracef(">>>>> LoginTarget, TargetName=%v", blockDev.TargetName)
+	defer log.Traceln("<<<<< LoginTarget")
 
 	// If the iSCSI iqn is not provided, fail the request
 	if blockDev.TargetName == "" {
@@ -108,8 +108,8 @@ func (plugin *IscsiPlugin) LoginTarget(blockDev model.BlockDeviceAccessInfo) (er
 
 // IsTargetLoggedIn checks to see if the given iSCSI target is already logged in
 func (plugin *IscsiPlugin) IsTargetLoggedIn(targetName string) (bool, error) {
-	log.Tracef(">>> IsTargetLoggedIn, targetName=%v", targetName)
-	defer log.Traceln("<<< IsTargetLoggedIn")
+	log.Tracef(">>>>> IsTargetLoggedIn, targetName=%v", targetName)
+	defer log.Traceln("<<<<< IsTargetLoggedIn")
 
 	// Call platform specific module
 	return plugin.isTargetLoggedIn(targetName)
@@ -117,8 +117,11 @@ func (plugin *IscsiPlugin) IsTargetLoggedIn(targetName string) (bool, error) {
 
 // LogoutTarget logs out the given iSCSI target
 func (plugin *IscsiPlugin) LogoutTarget(targetName string) error {
-	// TODO
-	return nil
+	log.Tracef(">>>>> LogoutTarget, TargetName=%v", targetName)
+	defer log.Traceln("<<<<< LogoutTarget")
+
+	// Call platform specific module
+	return plugin.logoutTarget(targetName)
 }
 
 // GetIscsiInitiators returns the host's iSCSI initiator object
@@ -133,7 +136,7 @@ func (plugin *IscsiPlugin) GetTargetScope(targetName string) (string, error) {
 
 // RescanIscsiTarget rescans host ports for iSCSI devices
 func (plugin *IscsiPlugin) RescanIscsiTarget(lunID string) error {
-	log.Tracef(">>> RescanIscsiTarget initiated for lunID %v", lunID)
-	defer log.Traceln("<<< RescanIscsiTarget")
+	log.Tracef(">>>>> RescanIscsiTarget initiated for lunID %v", lunID)
+	defer log.Traceln("<<<<< RescanIscsiTarget")
 	return rescanIscsiTarget(lunID)
 }

--- a/chapi2/iscsi/iscsi_linux.go
+++ b/chapi2/iscsi/iscsi_linux.go
@@ -15,8 +15,8 @@ const (
 )
 
 func getIscsiInitiators() (init *model.Initiator, err error) {
-	log.Info(">>>>> getIscsiInitiators")
-	defer log.Info("<<<<< getIscsiInitiators")
+	log.Trace(">>>>> getIscsiInitiators")
+	defer log.Trace("<<<<< getIscsiInitiators")
 
 	exists, _, err := util.FileExists(initiatorPath)
 	if !exists {
@@ -32,7 +32,7 @@ func getIscsiInitiators() (init *model.Initiator, err error) {
 		log.Errorf("empty iqn found from %s", initiatorPath)
 		return nil, cerrors.NewChapiError(cerrors.NotFound, errorMessageEmptyIqnFound)
 	}
-	log.Infof("got iscsi initiator name as %s", initiators[0])
+	log.Tracef("got iscsi initiator name as %s", initiators[0])
 	init = &model.Initiator{AccessProtocol: model.AccessProtocolIscsi, Init: initiators}
 	return init, err
 }
@@ -59,6 +59,12 @@ func (plugin *IscsiPlugin) getTargetPortals(targetName string, ipv4Only bool) ([
 // loginTarget is called to connect to the given iSCSI target.  The parent LoginTarget() routine
 // has already validated that target iqn and blockDev.IscsiAccessInfo are provided.
 func (plugin *IscsiPlugin) loginTarget(blockDev model.BlockDeviceAccessInfo) (err error) {
+	// TODO
+	return nil
+}
+
+// logoutTarget is called to disconnect the given iSCSI target from this host.
+func (plugin *IscsiPlugin) logoutTarget(targetName string) (err error) {
 	// TODO
 	return nil
 }

--- a/chapi2/iscsi/iscsi_windows.go
+++ b/chapi2/iscsi/iscsi_windows.go
@@ -178,10 +178,10 @@ func (plugin *IscsiPlugin) getTargetPortals(targetName string, ipv4Only bool) ([
 // loginTarget is called to connect to the given iSCSI target.  The parent LoginTarget() routine
 // has already validated that the target iqn and blockDev.IscsiAccessInfo are provided.
 func (plugin *IscsiPlugin) loginTarget(blockDev model.BlockDeviceAccessInfo) (err error) {
-	log.Trace(">>> loginTarget")
-	defer log.Trace("<<< loginTarget")
+	log.Trace(">>>>> loginTarget")
+	defer log.Trace("<<<<< loginTarget")
 
-	log.Infof("Login to iSCSI target %v", blockDev.TargetName)
+	log.Infof("Login iSCSI target %v", blockDev.TargetName)
 
 	// Determine how we should try to connect to the iSCSI target
 	var connectTypes []string
@@ -309,6 +309,17 @@ func (plugin *IscsiPlugin) loginTarget(blockDev model.BlockDeviceAccessInfo) (er
 	return nil
 }
 
+// logoutTarget is called to disconnect the given iSCSI target from this host.
+func (plugin *IscsiPlugin) logoutTarget(targetName string) (err error) {
+	log.Trace(">>>>> loginTarget")
+	defer log.Trace("<<<<< loginTarget")
+
+	log.Infof("Logout iSCSI target %v", targetName)
+
+	// Logout all iSCSI target sessions and remove persistent settings
+	return iscsidsc.LogoutIScsiTargetAll(targetName, true)
+}
+
 // connectTypeToArray takes the connectType string and returns an array of connection types that
 // reflect the input type.
 func (plugin *IscsiPlugin) connectTypeToArray(connectType string) (connectTypes []string, err error) {
@@ -336,8 +347,8 @@ func (plugin *IscsiPlugin) connectTypeToArray(connectType string) (connectTypes 
 
 // addDiscoveryPortal adds the given discovery IP to the system's discovery portals.
 func (plugin *IscsiPlugin) addDiscoveryPortal(discoveryIP string) error {
-	log.Tracef(">>> addDiscoveryPortal, discoveryIP=%v", discoveryIP)
-	defer log.Traceln("<<< addDiscoveryPortal")
+	log.Tracef(">>>>> addDiscoveryPortal, discoveryIP=%v", discoveryIP)
+	defer log.Traceln("<<<<< addDiscoveryPortal")
 
 	// Enumerate the send target portals (e.g. discovery IPs)
 	sendTargetPortals, err := iscsidsc.ReportIScsiSendTargetPortalsEx()
@@ -370,8 +381,8 @@ func (plugin *IscsiPlugin) addDiscoveryPortal(discoveryIP string) error {
 
 // isTargetLoggedIn checks to see if the given iSCSI target is already logged in.
 func (plugin *IscsiPlugin) isTargetLoggedIn(targetName string) (bool, error) {
-	log.Tracef(">>> isTargetLoggedIn, TargetName=%v", targetName)
-	defer log.Traceln("<<< isTargetLoggedIn")
+	log.Tracef(">>>>> isTargetLoggedIn, TargetName=%v", targetName)
+	defer log.Traceln("<<<<< isTargetLoggedIn")
 
 	// Get the current iSCSI session list
 	iscsiSessions, err := iscsidsc.GetIscsiSessionList()
@@ -393,8 +404,8 @@ func (plugin *IscsiPlugin) isTargetLoggedIn(targetName string) (bool, error) {
 // isTargetPresent returns nil if the given iSCSI target can be detected by this host, else an
 // applicable error is returned.
 func (plugin *IscsiPlugin) isTargetPresent(targetName string) error {
-	log.Tracef(">>> isTargetPresent, targetName=%v", targetName)
-	defer log.Traceln("<<< isTargetPresent")
+	log.Tracef(">>>>> isTargetPresent, targetName=%v", targetName)
+	defer log.Traceln("<<<<< isTargetPresent")
 
 	// Check to see if target is available through a discovery query.  If not found on the first
 	// query, perform a deep discovery and retry once more.
@@ -437,8 +448,8 @@ func (plugin *IscsiPlugin) loginTargetPorts(
 	loginExpiration time.Time,
 	maxConnectionCount uint32) (connections []ITNexus, err error) {
 
-	log.Tracef(">>> loginTargetPorts, targetName=%v", blockDev.TargetName)
-	defer log.Traceln("<<< loginTargetPorts")
+	log.Tracef(">>>>> loginTargetPorts, targetName=%v", blockDev.TargetName)
+	defer log.Traceln("<<<<< loginTargetPorts")
 
 	// Enumerate the IT_nexuses we should attempt to make connections with using the
 	// specified connection type.
@@ -509,8 +520,8 @@ func (plugin *IscsiPlugin) loginTargetPort(
 	targetPort *model.TargetPortal,
 	loginExpiration time.Time) error {
 
-	log.Tracef(">>> loginTargetPort, targetName=%v", blockDev.TargetName)
-	defer log.Traceln("<<< loginTargetPort")
+	log.Tracef(">>>>> loginTargetPort, targetName=%v", blockDev.TargetName)
+	defer log.Traceln("<<<<< loginTargetPort")
 
 	// If the amount of time given to login to an iSCSI target has expired, fail the
 	// request.

--- a/chapi2/model/types.go
+++ b/chapi2/model/types.go
@@ -124,7 +124,6 @@ type Device struct {
 	Pathname        string         `json:"path_name,omitempty"`          // Path name (e.g. "dm-3" for Linux, "Disk3" for Windows)
 	AltFullPathName string         `json:"alt_full_path_name,omitempty"` // Alternate path name (e.g. "/dev/mapper/mpathg" for Linux, "\\?\mpio#disk&ven_nimble&..." for Windows)
 	Size            uint64         `json:"size,omitempty"`               // Volume capacity in total number of bytes //TODO ensure clients/servers change from MiB to byte count
-	TargetScope     string         `json:"target_scope,omitempty"`       // GST="group", VST="volume" or empty if unknown scope or FC
 	State           string         `json:"state,omitempty"`              // TODO, Shiva to define states
 	IscsiTarget     *IscsiTarget   `json:"iscsi_target,omitempty"`       // Pointer to iSCSI target if device connected to an iSCSI target
 	Private         *DevicePrivate `json:"-"`                            // Private device properties used internally by CHAPI
@@ -137,7 +136,7 @@ type Device struct {
 // DevicePartition Partition Info for a Device
 type DevicePartition struct {
 	Name          string `json:"name,omitempty"`           // Partition name (e.g. "sda, mpathp1, mpathp2" for Linux, "Disk #1, Partition #0" for Windows)
-	Partitiontype string `json:"partition_type,omitempty"` // Partition type (e.g. "TODO" for Linux, "GPT: Basic Data" for Windows)
+	PartitionType string `json:"partition_type,omitempty"` // Partition type (e.g. "TODO" for Linux, "GPT: Basic Data" for Windows)
 	Size          uint64 `json:"size,omitempty"`           // Partition size in total number of bytes
 }
 

--- a/chapi2/mount/mount.go
+++ b/chapi2/mount/mount.go
@@ -51,8 +51,8 @@ func (mounter *Mounter) GetAllMountDetails(serialNumber string, mountId string) 
 
 // CreateMount is called to mount the given device to the given mount point
 func (mounter *Mounter) CreateMount(serialNumber string, mountPoint string, fsOptions *model.FileSystemOptions) (*model.Mount, error) {
-	log.Infof(">>>>> CreateMount, serialNumber=%v, mountPoint=%v, fsOptions=%v", serialNumber, mountPoint, fsOptions)
-	defer log.Info("<<<<< CreateMount")
+	log.Tracef(">>>>> CreateMount, serialNumber=%v, mountPoint=%v, fsOptions=%v", serialNumber, mountPoint, fsOptions)
+	defer log.Trace("<<<<< CreateMount")
 
 	// Validate and enumerate the mount object for the given serial number and mount point
 	mount, alreadyMounted, err := mounter.getMountForCreate(serialNumber, mountPoint)
@@ -80,8 +80,8 @@ func (mounter *Mounter) CreateMount(serialNumber string, mountPoint string, fsOp
 
 // DeleteMount is called to unmount the given mount point ID
 func (mounter *Mounter) DeleteMount(serialNumber string, mountId string) error {
-	log.Infof(">>>>> DeleteMount, serialNumber=%v, mountId=%v", serialNumber, mountId)
-	defer log.Info("<<<<< DeleteMount")
+	log.Tracef(">>>>> DeleteMount, serialNumber=%v, mountId=%v", serialNumber, mountId)
+	defer log.Trace("<<<<< DeleteMount")
 
 	// Validate and enumerate the mount object for the given serial number and mount point ID
 	mount, err := mounter.getMountForDelete(serialNumber, mountId)
@@ -114,8 +114,8 @@ func (mounter *Mounter) enumerateDevices(serialNumber string, allDetails bool) (
 //      err             - If volume cannot be mounted, an error object is returned ("mount" and
 //                        "alreadyMounted" are invalid)
 func (mounter *Mounter) getMountForCreate(serialNumber string, mountPoint string) (mount *model.Mount, alreadyMounted bool, err error) {
-	log.Infof(">>>>> getMountForCreate, serialNumber=%v, mountPoint=%v", serialNumber, mountPoint)
-	defer log.Info("<<<<< getMountForCreate")
+	log.Tracef(">>>>> getMountForCreate, serialNumber=%v, mountPoint=%v", serialNumber, mountPoint)
+	defer log.Trace("<<<<< getMountForCreate")
 
 	// If the serialNumber is not provided, fail the request
 	if serialNumber == "" {
@@ -177,7 +177,7 @@ func (mounter *Mounter) getMountForCreate(serialNumber string, mountPoint string
 		// If the current mount point matches the target mount point, there is nothing to do as we
 		// are already mounted at the requested location.
 		if isSamePathName(currentMountPoint, requestedMountPoint) {
-			log.Infof(`Mount point ID=%v, SerialNumber=%v, currentMountPoint=%v, already mounted`, mount.ID, mount.SerialNumber, currentMountPoint)
+			log.Tracef(`Mount point ID=%v, SerialNumber=%v, currentMountPoint=%v, already mounted`, mount.ID, mount.SerialNumber, currentMountPoint)
 			return mount, true, nil
 		}
 
@@ -197,8 +197,8 @@ func (mounter *Mounter) getMountForCreate(serialNumber string, mountPoint string
 //      mount             - Enumerated model.Mount object for the provided serialNumber/mountPointId
 //      err               - If volume cannot be dismounted, an error object is returned
 func (mounter *Mounter) getMountForDelete(serialNumber string, mountId string) (mount *model.Mount, err error) {
-	log.Infof(">>>>> getMountForDelete, serialNumber=%v, mountId=%v", serialNumber, mountId)
-	defer log.Info("<<<<< getMountForDelete")
+	log.Tracef(">>>>> getMountForDelete, serialNumber=%v, mountId=%v", serialNumber, mountId)
+	defer log.Trace("<<<<< getMountForDelete")
 
 	// If the serialNumber is not provided, fail the request
 	if serialNumber == "" {
@@ -234,8 +234,8 @@ func (mounter *Mounter) getMountForDelete(serialNumber string, mountId string) (
 
 // logMountPoints logs the mount points array to our log file
 func logMountPoints(mountPoints []*model.Mount, allDetails bool) {
-	log.Infof(">>>>> logMountPoints, allDetails=%v", allDetails)
-	defer log.Info("<<<<< logMountPoints")
+	log.Tracef(">>>>> logMountPoints, allDetails=%v", allDetails)
+	defer log.Trace("<<<<< logMountPoints")
 
 	for _, mountPoint := range mountPoints {
 		logMessage := "Enumerated mount point, ID=" + mountPoint.ID
@@ -243,7 +243,7 @@ func logMountPoints(mountPoints []*model.Mount, allDetails bool) {
 			logMessage += ", SerialNumber=" + mountPoint.SerialNumber
 			logMessage += ", MountPoint=" + mountPoint.MountPoint
 		}
-		log.Info(logMessage)
+		log.Trace(logMessage)
 	}
 }
 

--- a/chapi2/multipath/multipath_linux.go
+++ b/chapi2/multipath/multipath_linux.go
@@ -12,8 +12,8 @@ import (
 // getDevices enumerates all the Nimble volumes while only providing basic details (e.g. serial number).
 // If a "serialNumber" is passed in, only that specific serial number is enumerated.
 func (plugin *MultipathPlugin) getDevices(serialNumber string) ([]*model.Device, error) {
-	log.Infof(">>>>> getDevices, serialNumber=%v", serialNumber)
-	defer log.Info("<<<<< getDevices")
+	log.Tracef(">>>>> getDevices, serialNumber=%v", serialNumber)
+	defer log.Trace("<<<<< getDevices")
 	// TODO
 	return nil, nil
 }
@@ -21,24 +21,24 @@ func (plugin *MultipathPlugin) getDevices(serialNumber string) ([]*model.Device,
 // getDevices enumerates all the Nimble volumes while providing full details about the device.
 // If a "serialNumber" is passed in, only that specific serial number is enumerated.
 func (plugin *MultipathPlugin) getAllDeviceDetails(serialNumber string) ([]*model.Device, error) {
-	log.Info(">>>>> getAllDeviceDetails")
-	defer log.Info("<<<<< getAllDeviceDetails")
+	log.Trace(">>>>> getAllDeviceDetails")
+	defer log.Trace("<<<<< getAllDeviceDetails")
 	// TODO
 	return nil, nil
 }
 
 // getPartitionInfo enumerates the partitions on the given volume
 func (plugin *MultipathPlugin) getPartitionInfo(serialNumber string) ([]*model.DevicePartition, error) {
-	log.Infof(">>>>> getPartitionInfo, serialNumber=%v", serialNumber)
-	defer log.Info("<<<<< getPartitionInfo")
+	log.Tracef(">>>>> getPartitionInfo, serialNumber=%v", serialNumber)
+	defer log.Trace("<<<<< getPartitionInfo")
 	// TODO
 	return nil, nil
 }
 
 // offlineDevice is called to offline the given device
 func (plugin *MultipathPlugin) offlineDevice(device model.Device) error {
-	log.Infof(">>>>> offlineDevice")
-	defer log.Info("<<<<< offlineDevice")
+	log.Tracef(">>>>> offlineDevice")
+	defer log.Trace("<<<<< offlineDevice")
 
 	// TODO
 	return nil
@@ -46,8 +46,8 @@ func (plugin *MultipathPlugin) offlineDevice(device model.Device) error {
 
 // createFileSystem is called to create a file system on the given device
 func (plugin *MultipathPlugin) createFileSystem(device model.Device, filesystem string) error {
-	log.Infof(">>>>> createFileSystem")
-	defer log.Info("<<<<< createFileSystem")
+	log.Tracef(">>>>> createFileSystem")
+	defer log.Trace("<<<<< createFileSystem")
 
 	// TODO
 	return nil

--- a/windows/iscsidsc/iscsidsc.go
+++ b/windows/iscsidsc/iscsidsc.go
@@ -6,11 +6,15 @@
 package iscsidsc
 
 import (
+	"encoding/hex"
 	"math"
+	"strings"
 	"syscall"
 	"unsafe"
 
+	log "github.com/hpe-storage/common-host-libs/logger"
 	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
 )
 
@@ -463,4 +467,18 @@ func safeUTF16PtrToString(ptr *uint16) (str string) {
 		str = syscall.UTF16ToString((*[1024]uint16)(unsafe.Pointer(ptr))[:])
 	}
 	return str
+}
+
+// logTraceHexDump dumps the given hex buffer to the trace log (if enabled)
+func logTraceHexDump(dataBuffer []uint8, prefix string) {
+	if !log.IsLevelEnabled(logrus.TraceLevel) {
+		return
+	}
+	if prefix != "" {
+		prefix += " - "
+	}
+	hexStrings := strings.Split(strings.TrimRight(hex.Dump(dataBuffer), "\r\n"), "\n")
+	for _, hexString := range hexStrings {
+		log.Tracef("%v%v", prefix, hexString)
+	}
 }

--- a/windows/iscsidsc/send_scsi_inquiry.go
+++ b/windows/iscsidsc/send_scsi_inquiry.go
@@ -6,10 +6,10 @@
 package iscsidsc
 
 import (
-	"encoding/hex"
-	log "github.com/hpe-storage/common-host-libs/logger"
 	"syscall"
 	"unsafe"
+
+	log "github.com/hpe-storage/common-host-libs/logger"
 )
 
 // SendScsiInquiry - Go wrapped Win32 API - SendScsiInquiry()
@@ -41,7 +41,7 @@ func SendScsiInquiry(sessionID ISCSI_UNIQUE_SESSION_ID, lun uint64, evpdCmddt ui
 	if scsiStatus == SCSISTAT_CHECK_CONDITION {
 		// Only return the data that the iSCSI initiator claims was returned by the target
 		senseBuffer = senseBuffer[:senseBufferSize]
-		log.Tracef("Sense Data\n%v", hex.Dump(senseBuffer))
+		logTraceHexDump(senseBuffer, "Sense Data")
 	} else {
 		// Empty sense buffer if no check condition
 		senseBuffer = nil
@@ -59,7 +59,7 @@ func SendScsiInquiry(sessionID ISCSI_UNIQUE_SESSION_ID, lun uint64, evpdCmddt ui
 		inquiryBuffer = inquiryBuffer[:inquiryBufferSize]
 
 		// Log the Inquiry data
-		log.Tracef("Inquiry Data\n%v", hex.Dump(inquiryBuffer))
+		logTraceHexDump(inquiryBuffer, "Inquiry Data")
 	}
 
 	// Log the SCSI status

--- a/windows/powershell/disk_cmdlets.go
+++ b/windows/powershell/disk_cmdlets.go
@@ -20,6 +20,9 @@ const (
 
 	// PartitionStyleGPT is used to initialize a disk with the GPT partitioning style
 	PartitionStyleGPT = "GPT"
+
+	// TimeoutPartitionAndFormatVolume specifies the partition and format cmdlet timeout (in seconds)
+	TimeoutPartitionAndFormatVolume = 5 * 60
 )
 
 // AddPartitionAccessPath wraps the Add-PartitionAccessPath cmdlet
@@ -68,7 +71,7 @@ func PartitionAndFormatVolume(diskPath string, fileSystem string) (string, int, 
 	}
 
 	arg := fmt.Sprintf(`New-Partition -DiskPath "%v" -UseMaximumSize:$True | Format-Volume -FileSystem %v`, diskPath, fileSystem)
-	return execCommandOutput(arg)
+	return execCommandOutputWithTimeout(arg, TimeoutPartitionAndFormatVolume)
 }
 
 // RemovePartitionAccessPath wraps the Remove-PartitionAccessPath cmdlet


### PR DESCRIPTION
* Problem:
  * Add DeleteDevice endpoint support for Windows
  * Improve logging so that Info and Trace levels are used efficiently
* Implementation:
  * Across multiple packages, replaced log.Info with log.Trace where applicable
  * Replaced entry/exit ">>>" with ">>>>>" logging to be consistent within CHAPI2 and Windows base libraries
  * chapi2 types
    * Removed "TargetScope" from "Device" object.  It's redundant and already included as an IScsiTarget property (where it belongs)
    * Renamed "Partitiontype" with "PartitionType" in "DevicePartition" object (correct CamelCase issue)
  * chapi2 driver package
    * Added additional Info level logging to provide a high level overview of which endpoints are being called and their return data
    * Implemented DeleteDevice() endpoint
      * If serial number not present, return no error (e.g. device already deleted)
      * If device mounted, fail request (e.g. device must be dismounted before deleted)
  * chapi2 iscsi package
    * Implemented LogoutTarget() method for Windows; put stub in for Linux
  * chapi2 multipath package
    * Implemented DetachDevice() method
      * Offline volume on host first
      * If it's an iSCSI VST, logout the iSCSI connections as well (else leave iSCSI connections intact)
      * For Windows, before formatting a volume, we now make sure the disk is online and writable.  We also use MBR partition if the disk is < 128 MiB, else GPT is used.
  * chapi2 mount package
    * For Windows, moved MakeDiskOnlineAndWritable() method from mount to multipath package
* Testing:
  * Successfully built on Windows and Linux
  * Reviewed log output files with both "trace" and "info" log level set
  * Used PS script to exercise each endpoint under Windows
* Reviewers:
  * @shivamerla, @suneeth51
* Bug: N/A