### PR TITLE
chapi2: endpoint cleanup

### DIFF
--- a/chapi2/chapi.go
+++ b/chapi2/chapi.go
@@ -141,7 +141,7 @@ func NewRouter() *mux.Router {
 		},
 
 		///////////////////////////////////////////////////////////////////////////////////////////
-		// Endpoint:  		GET /api/v1/devices/detail
+		// Endpoint:  		GET /api/v1/devices/details
 		// Description: 	This endpoint returns all the Nimble volumes attached to the host
 		// Input Object:	None
 		// Output Object:	Array of chapi2.Device objects with detailed information
@@ -176,7 +176,7 @@ func NewRouter() *mux.Router {
 		util.Route{
 			Name:        "AllDeviceDetails",
 			Method:      "GET",
-			Pattern:     "/api/v1/devices/detail",
+			Pattern:     "/api/v1/devices/details",
 			HandlerFunc: handler.GetAllDeviceDetails,
 		},
 
@@ -217,7 +217,7 @@ func NewRouter() *mux.Router {
 		//                          "serial_number":  "28174883c7719ac236c9ce900584f2795"
 		//                      }
 		//                  ]
-		// Sample Output:	See "GET /api/v1/devices/detail" endpoint
+		// Sample Output:	See "GET /api/v1/devices/details" endpoint
 		///////////////////////////////////////////////////////////////////////////////////////////
 		util.Route{
 			Name:        "CreateDevice",

--- a/chapi2/driver/driver.go
+++ b/chapi2/driver/driver.go
@@ -49,8 +49,8 @@ type Driver interface {
 	// GET /api/v1/devices?serialNumber=serial
 	GetDevices(serialNumber string) ([]*model.Device, error)
 
-	// GET /api/v1/devices/detail or
-	// GET /api/v1/devices/detail?serialNumber=serial
+	// GET /api/v1/devices/details or
+	// GET /api/v1/devices/details?serialNumber=serial
 	GetAllDeviceDetails(serialNumber string) ([]*model.Device, error)
 
 	// GET /api/v1/devices/{serialnumber}/partitions
@@ -66,10 +66,10 @@ type Driver interface {
 	OfflineDevice(serialNumber string) error
 
 	// PUT /api/v1/devices/{serialnumber}/filesystem/{filesystem}
-	CreateFileSystem(serialNumber string, fsType string) error
+	CreateFileSystem(serialNumber string, filesystem string) error
 
 	///////////////////////////////////////////////////////////////////////////////////////////
-	// Filesystem Methods
+	// Mount Methods
 	///////////////////////////////////////////////////////////////////////////////////////////
 
 	// GET /api/v1/mounts or
@@ -79,7 +79,7 @@ type Driver interface {
 	// GET /api/v1/mounts/details  or filter by serial using
 	// GET /api/v1/mounts/details?serialNumber=serial or filter by serial and specific mount using
 	// GET /api/v1/mounts/details?serialNumber=serial,mountId=mount
-	GetAllMountDetails(serialNumber, mountPointId string) ([]*model.Mount, error)
+	GetAllMountDetails(serialNumber, mountPointID string) ([]*model.Mount, error)
 
 	// POST /api/v1/mounts
 	CreateMount(serialNumber string, mountPoint string, fsOptions *model.FileSystemOptions) (*model.Mount, error)
@@ -433,15 +433,15 @@ func (driver *ChapiServer) GetMounts(serialNumber string) ([]*model.Mount, error
 }
 
 // GetAllMountDetails enumerates the specified mount point ID
-func (driver *ChapiServer) GetAllMountDetails(serialNumber string, mountId string) ([]*model.Mount, error) {
-	log.Tracef(">>>>> GetMount called, serialNumber=%v, mountPointID=%v", serialNumber, mountId)
-	defer log.Trace("<<<<< GetMount")
+func (driver *ChapiServer) GetAllMountDetails(serialNumber string, mountPointID string) ([]*model.Mount, error) {
+	log.Tracef(">>>>> GetAllMountDetails called, serialNumber=%v, mountPointID=%v", serialNumber, mountPointID)
+	defer log.Trace("<<<<< GetAllMountDetails")
 
-	log.Infof("Get All Mount Details, serialNumber=%v, mountId=%v", serialNumber, mountId)
+	log.Infof("Get All Mount Details, serialNumber=%v, mountPointID=%v", serialNumber, mountPointID)
 
 	// Route request to the mount package to get the mounts
 	mountPlugin := mount.NewMounter()
-	mounts, err := mountPlugin.GetAllMountDetails(serialNumber, mountId)
+	mounts, err := mountPlugin.GetAllMountDetails(serialNumber, mountPointID)
 	if err != nil {
 		return nil, err
 	}
@@ -491,7 +491,7 @@ func (driver *ChapiServer) DeleteMount(serialNumber string, mountPointId string)
 	return nil
 }
 
-// CreateBindMount unmounts the given mount point
+// CreateBindMount creates the given bind mount
 func (driver *ChapiServer) CreateBindMount(sourceMount string, targetMount string, bindType string) (*model.Mount, error) {
 	log.Tracef(">>>>> CreateBindMount called, sourceMount=%s, targetMount=%s bindType=%s", sourceMount, targetMount, bindType)
 	defer log.Trace("<<<<< CreateBindMount")

--- a/chapi2/handler/handler.go
+++ b/chapi2/handler/handler.go
@@ -138,7 +138,7 @@ func GetDevices(w http.ResponseWriter, r *http.Request) {
 //@Accept json
 //@Resource /api/v1/devices
 //@Success 200 {array} Devices
-//@Router /api/v1/devices/detail [get]
+//@Router /api/v1/devices/details [get]
 func GetAllDeviceDetails(w http.ResponseWriter, r *http.Request) {
 	if !validateRequestHeader(w, r) {
 		return
@@ -351,7 +351,7 @@ func GetMounts(w http.ResponseWriter, r *http.Request) {
 //@Accept json
 //@Resource /api/v1/mounts
 //@Success 200 {array} Mounts
-//@Router /api/v1/mounts/detail [get]
+//@Router /api/v1/mounts/details [get]
 func GetAllMountDetails(w http.ResponseWriter, r *http.Request) {
 	if !validateRequestHeader(w, r) {
 		return


### PR DESCRIPTION
* Problem:
  * CHAPI2 endpoint cleanup
* Implementation:
  * To align with mounts endpoint, change /api/v1/devices/detail endpoint to /api/v1/devices/details
  * In driver.go, align interface parameter definitions with actual implementation
  * Minor comment cleanup
* Testing:
  * Built successfully for Linux and Windows
  * Exercised endpoints under Windows
* Reviewers:
  * @shivamerla
* Bug: N/A