### PR TITLE
chapi2: Add chapiclient package

### DIFF
--- a/chapi2/chapiclient/chapiclient.go
+++ b/chapi2/chapiclient/chapiclient.go
@@ -124,7 +124,7 @@ func (chapiClient *Client) GetHostNetworks() (networks []*model.Network, err err
 
 	// Initialize CHAPI response object, submit request to specified endpoint, return status
 	chapiResp := Response{Data: &networks, Err: nil}
-	if _, err = chapiClient.client.DoJSON(&connectivity.Request{Action: "GET", Path: networksURI, Header: chapiClient.header, Payload: nil, Response: &chapiResp, ResponseError: &chapiResp}); err != nil {
+	if _, err = chapiClient.chapiClientDoJSON(&connectivity.Request{Action: "GET", Path: networksURI, Header: chapiClient.header, Payload: nil, Response: &chapiResp, ResponseError: &chapiResp}); err != nil {
 		return nil, err
 	}
 	return networks, nil

--- a/chapi2/chapiclient/chapiclient.go
+++ b/chapi2/chapiclient/chapiclient.go
@@ -1,0 +1,366 @@
+// (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+
+package chapiclient
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hpe-storage/common-host-libs/chapi2/cerrors"
+	chapiDriver "github.com/hpe-storage/common-host-libs/chapi2/driver"
+	"github.com/hpe-storage/common-host-libs/chapi2/model"
+	"github.com/hpe-storage/common-host-libs/connectivity"
+	log "github.com/hpe-storage/common-host-libs/logger"
+)
+
+const (
+	// REST endpoint API version
+	apiVersion = "api/v1"
+
+	// Host Endpoints
+	hostURI       = apiVersion + "/hosts"      // api/v1/hosts
+	initiatorsURI = apiVersion + "/initiators" // api/v1/initiators
+	networksURI   = apiVersion + "/networks"   // api/v1/networks
+
+	// Device Endpoints
+	devicesURI           = apiVersion + "/devices"            // api/v1/devices
+	devicesDetailURI     = devicesURI + "/details"            // api/v1/devices/details
+	devicesPartitionsURI = devicesURI + "/%v/partitions"      // api/v1/devices/{serialnumber}/partitions
+	devicesOfflineURI    = devicesURI + "/%v/actions/offline" // api/v1/devices/{serialnumber}/actions/offline
+	devicesFileSystemURI = devicesURI + "/%v/%v"              // api/v1/devices/{serialnumber}/filesystem/{filesystem}
+
+	// Mount Endpoints
+	mountsURI       = apiVersion + "/mounts" // api/v1/mounts
+	mountsDetailURI = mountsURI + "/details" // api/v1/mounts/details
+	mountsDeleteURI = mountsURI + "/%v"      // api/v1/mounts/{mountId}
+)
+
+const (
+	// Query Parameters
+	queryMountID      = "mountId" // e.g. api/v1/mounts/details?serial=1234&mountId=5678
+	querySerialNumber = "serial"  // e.g. api/v1/devices/details?serial=1234
+)
+
+// ClientBase defines platform independent properties and is embedded within the Client object
+type ClientBase struct {
+	client *connectivity.Client // HTTP client for connectivity to chapid server
+	header map[string]string    // HTTP headers
+}
+
+var (
+	// The "dummy" object is declared so that the Client object is required to support all the
+	// chapiDriver.Driver methods.  If any are missing, a compilation error will occur.  This
+	// ensures that the CHAPI client methods stay aligned with the CHAPI server methods.
+	dummy chapiDriver.Driver = &Client{}
+)
+
+// Response object defines the data and/or error that are returned by a CHAPI endpoint
+type Response struct {
+	Data interface{}         `json:"data,omitempty"`
+	Err  *cerrors.ChapiError `json:"errors,omitempty"`
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// CHAPI Client Initialization
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+// NewChapiClient returns the CHAPI client object that is used to communicate with the CHAPI server
+// over HTTP.
+func NewChapiClient() (*Client, error) {
+	return newChapiClient() // Reflect to platform specific handler
+}
+
+// NewChapiClientWithTimeout returns the CHAPI client object that is used to communicate with the
+// CHAPI server over HTTP.  A custom timeout value is supported.
+func NewChapiClientWithTimeout(timeout time.Duration) (*Client, error) {
+	return newChapiClientWithTimeout(timeout) // Reflect to platform specific handler
+}
+
+// Print to dump CHAPI client struct
+func (chapiClient *Client) Print() {
+	chapiClient.Print() // Reflect to platform specific handler
+}
+
+// addHeader is used to insert HTTP headers with each CHAPI request
+func (chapiClient *Client) addHeader(header map[string]string) {
+	chapiClient.header = header
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Host Methods
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+// GetHostInfo returns host name, domain, and network interfaces
+func (chapiClient *Client) GetHostInfo() (host *model.Host, err error) {
+	log.Trace(">>>>> GetHostInfo called")
+	defer log.Trace("<<<<< GetHostInfo")
+
+	// Initialize CHAPI response object, submit request to specified endpoint, return status
+	chapiResp := Response{Data: &host, Err: nil}
+	if _, err = chapiClient.chapiClientDoJSON(&connectivity.Request{Action: "GET", Path: hostURI, Header: chapiClient.header, Payload: nil, Response: &chapiResp, ResponseError: &chapiResp}); err != nil {
+		return nil, err
+	}
+	return host, nil
+}
+
+// GetHostInitiators reports the initiators on this host
+func (chapiClient *Client) GetHostInitiators() (initiators []*model.Initiator, err error) {
+	log.Trace(">>>>> GetHostInitiators called")
+	defer log.Trace("<<<<< GetHostInitiators")
+
+	// Initialize CHAPI response object, submit request to specified endpoint, return status
+	chapiResp := Response{Data: &initiators, Err: nil}
+	if _, err = chapiClient.chapiClientDoJSON(&connectivity.Request{Action: "GET", Path: initiatorsURI, Header: chapiClient.header, Payload: nil, Response: &chapiResp, ResponseError: &chapiResp}); err != nil {
+		return nil, err
+	}
+	return initiators, nil
+}
+
+// GetHostNetworks reports the networks on this host
+func (chapiClient *Client) GetHostNetworks() (networks []*model.Network, err error) {
+	log.Trace(">>>>> GetHostNetworks called")
+	defer log.Trace("<<<<< GetHostNetworks")
+
+	// Initialize CHAPI response object, submit request to specified endpoint, return status
+	chapiResp := Response{Data: &networks, Err: nil}
+	if _, err = chapiClient.client.DoJSON(&connectivity.Request{Action: "GET", Path: networksURI, Header: chapiClient.header, Payload: nil, Response: &chapiResp, ResponseError: &chapiResp}); err != nil {
+		return nil, err
+	}
+	return networks, nil
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Device methods
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+// GetDevices enumerates all the Nimble volumes with basic details.
+// If serialNumber is non-empty then only specified device is returned
+func (chapiClient *Client) GetDevices(serialNumber string) (devices []*model.Device, err error) {
+	log.Tracef(">>>>> GetDevices called, serialNumber=%v", serialNumber)
+	defer log.Trace("<<<<< GetDevices")
+
+	// Initialize CHAPI response object, submit request to specified endpoint, return status
+	chapiResp := Response{Data: &devices, Err: nil}
+	devicesURIOut := chapiClient.appendQuerySerialNumber(devicesURI, serialNumber)
+	if _, err = chapiClient.chapiClientDoJSON(&connectivity.Request{Action: "GET", Path: devicesURIOut, Header: chapiClient.header, Payload: nil, Response: &chapiResp, ResponseError: &chapiResp}); err != nil {
+		return nil, err
+	}
+	return devices, nil
+}
+
+// GetAllDeviceDetails enumerates all the Nimble volumes with detailed information.
+// If serialNumber is non-empty then only specified device is returned
+func (chapiClient *Client) GetAllDeviceDetails(serialNumber string) (devices []*model.Device, err error) {
+	log.Tracef(">>>>> GetAllDeviceDetails called, serialNumber=%v", serialNumber)
+	defer log.Trace("<<<<< GetAllDeviceDetails")
+
+	// Initialize CHAPI response object, submit request to specified endpoint, return status
+	chapiResp := Response{Data: &devices, Err: nil}
+	devicesURIOut := chapiClient.appendQuerySerialNumber(devicesDetailURI, serialNumber)
+	if _, err = chapiClient.chapiClientDoJSON(&connectivity.Request{Action: "GET", Path: devicesURIOut, Header: chapiClient.header, Payload: nil, Response: &chapiResp, ResponseError: &chapiResp}); err != nil {
+		return nil, err
+	}
+	return devices, nil
+}
+
+// GetPartitionInfo reports the partitions on the provided device
+func (chapiClient *Client) GetPartitionInfo(serialNumber string) (partitions []*model.DevicePartition, err error) {
+	log.Tracef(">>>>> GetPartitionInfo called, serialNumber=%v", serialNumber)
+	defer log.Trace("<<<<< GetPartitionInfo")
+
+	// Initialize CHAPI response object, submit request to specified endpoint, return status
+	chapiResp := Response{Data: &partitions, Err: nil}
+	devicePartitionsURIOut := fmt.Sprintf(devicesPartitionsURI, serialNumber)
+	if _, err = chapiClient.chapiClientDoJSON(&connectivity.Request{Action: "GET", Path: devicePartitionsURIOut, Header: chapiClient.header, Payload: nil, Response: &chapiResp, ResponseError: &chapiResp}); err != nil {
+		return nil, err
+	}
+	return partitions, nil
+}
+
+// CreateDevice will attach device on this host based on the details provided
+func (chapiClient *Client) CreateDevice(publishInfo model.PublishInfo) (device *model.Device, err error) {
+	log.Tracef(">>>>> CreateDevice called, publishInfo=%v", publishInfo)
+	defer log.Trace("<<<<< CreateDevice")
+
+	// Initialize CHAPI response object, submit request to specified endpoint, return status
+	chapiResp := Response{Data: &device, Err: nil}
+	if _, err = chapiClient.chapiClientDoJSON(&connectivity.Request{Action: "POST", Path: devicesURI, Header: chapiClient.header, Payload: &publishInfo, Response: &chapiResp, ResponseError: &chapiResp}); err != nil {
+		return nil, err
+	}
+	return device, nil
+}
+
+// DeleteDevice will delete the given device from the host
+func (chapiClient *Client) DeleteDevice(serialNumber string) (err error) {
+	log.Tracef(">>>>> DeleteDevice called, serialNumber=%v", serialNumber)
+	defer log.Trace("<<<<< DeleteDevice")
+
+	// Initialize CHAPI response object, submit request to specified endpoint, return status
+	chapiResp := Response{Data: nil, Err: nil}
+	devicesURIOut := devicesURI + "/" + serialNumber
+	if _, err = chapiClient.chapiClientDoJSON(&connectivity.Request{Action: "DELETE", Path: devicesURIOut, Header: chapiClient.header, Payload: nil, Response: &chapiResp, ResponseError: &chapiResp}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// OfflineDevice will offline the given device from the host
+func (chapiClient *Client) OfflineDevice(serialNumber string) (err error) {
+	log.Tracef(">>>>> OfflineDevice called, serialNumber=%v", serialNumber)
+	defer log.Trace("<<<<< OfflineDevice")
+
+	// Initialize CHAPI response object, submit request to specified endpoint, return status
+	chapiResp := Response{Data: nil, Err: nil}
+	deviceOfflineURIOut := fmt.Sprintf(devicesOfflineURI, serialNumber)
+	if _, err = chapiClient.chapiClientDoJSON(&connectivity.Request{Action: "PUT", Path: deviceOfflineURIOut, Header: chapiClient.header, Payload: nil, Response: &chapiResp, ResponseError: &chapiResp}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// CreateFileSystem writes the given file system to the device with the given serial number
+func (chapiClient *Client) CreateFileSystem(serialNumber string, filesystem string) (err error) {
+	log.Tracef(">>>>> CreateFileSystem called, serialNumber=%v, filesystem=%v", serialNumber, filesystem)
+	defer log.Trace("<<<<< CreateFileSystem")
+
+	// Initialize CHAPI response object, submit request to specified endpoint, return status
+	chapiResp := Response{Data: nil, Err: nil}
+	deviceFileSystemURIOut := fmt.Sprintf(devicesFileSystemURI, serialNumber, filesystem)
+	if _, err = chapiClient.chapiClientDoJSON(&connectivity.Request{Action: "PUT", Path: deviceFileSystemURIOut, Header: chapiClient.header, Payload: nil, Response: &chapiResp, ResponseError: &chapiResp}); err != nil {
+		return err
+	}
+	return nil
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Mount Methods
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+// GetMounts reports all mounts on this host for the specified Nimble volume
+func (chapiClient *Client) GetMounts(serialNumber string) (mounts []*model.Mount, err error) {
+	log.Tracef(">>>>> GetMounts called, serialNumber=%v", serialNumber)
+	defer log.Trace("<<<<< GetMounts")
+
+	// Initialize CHAPI response object, submit request to specified endpoint, return status
+	chapiResp := Response{Data: &mounts, Err: nil}
+	mountsURIOut := chapiClient.appendQuerySerialNumber(mountsURI, serialNumber)
+	if _, err = chapiClient.chapiClientDoJSON(&connectivity.Request{Action: "GET", Path: mountsURIOut, Header: chapiClient.header, Payload: nil, Response: &chapiResp, ResponseError: &chapiResp}); err != nil {
+		return nil, err
+	}
+	return mounts, nil
+}
+
+// GetAllMountDetails enumerates the specified mount point ID
+func (chapiClient *Client) GetAllMountDetails(serialNumber, mountPointID string) (mounts []*model.Mount, err error) {
+	log.Tracef(">>>>> GetAllMountDetails called, serialNumber=%v, mountPointID=%v", serialNumber, mountPointID)
+	defer log.Trace("<<<<< GetAllMountDetails")
+
+	// Initialize CHAPI response object, submit request to specified endpoint, return status
+	chapiResp := Response{Data: &mounts, Err: nil}
+	mountsURIOut := chapiClient.appendQuerySerialNumber(mountsDetailURI, serialNumber)
+	mountsURIOut = chapiClient.appendQueryMountPointID(mountsURIOut, mountPointID)
+	if _, err = chapiClient.chapiClientDoJSON(&connectivity.Request{Action: "GET", Path: mountsURIOut, Header: chapiClient.header, Payload: nil, Response: &chapiResp, ResponseError: &chapiResp}); err != nil {
+		return nil, err
+	}
+	return mounts, nil
+}
+
+// CreateMount mounts the given device to the given mount point
+func (chapiClient *Client) CreateMount(serialNumber string, mountPoint string, fsOptions *model.FileSystemOptions) (mount *model.Mount, err error) {
+	log.Tracef(">>>>> CreateMount called, serialNumber=%v, mountPoint=%v, fsOptions=%v", serialNumber, mountPoint, fsOptions)
+	defer log.Trace("<<<<< CreateMount")
+
+	// Initialize model.Mount submission object
+	mountSubmission := model.Mount{
+		SerialNumber: serialNumber,
+		MountPoint:   mountPoint,
+		FsOpts:       fsOptions,
+	}
+
+	// Initialize CHAPI response object, submit request to specified endpoint, return status
+	chapiResp := Response{Data: &mount, Err: nil}
+	if _, err = chapiClient.chapiClientDoJSON(&connectivity.Request{Action: "POST", Path: mountsURI, Header: chapiClient.header, Payload: &mountSubmission, Response: &chapiResp, ResponseError: &chapiResp}); err != nil {
+		return nil, err
+	}
+	return mount, nil
+}
+
+// DeleteMount unmounts the given mount point, serialNumber can be optional in the body
+func (chapiClient *Client) DeleteMount(serialNumber, mountPointID string) (err error) {
+	log.Tracef(">>>>> DeleteMount called, serialNumber=%v, mountPointID=%v", serialNumber, mountPointID)
+	defer log.Trace("<<<<< DeleteMount")
+
+	// Initialize CHAPI response object, submit request to specified endpoint, return status
+	chapiResp := Response{Data: nil, Err: nil}
+	mountsDeleteURIOut := fmt.Sprintf(mountsDeleteURI, mountPointID)
+	if _, err = chapiClient.chapiClientDoJSON(&connectivity.Request{Action: "DELETE", Path: mountsDeleteURIOut, Header: chapiClient.header, Payload: serialNumber, Response: &chapiResp, ResponseError: &chapiResp}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// CreateBindMount creates the given bind mount
+func (chapiClient *Client) CreateBindMount(sourceMount string, targetMount string, bindType string) (mount *model.Mount, err error) {
+	log.Tracef(">>>>> CreateBindMount called, sourceMount=%s, targetMount=%s bindType=%s", sourceMount, targetMount, bindType)
+	defer log.Trace("<<<<< CreateBindMount")
+
+	// TODO
+	return nil, cerrors.NewChapiError(cerrors.Unimplemented)
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Internal Support Methods
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+// chapiClientDoJSON wraps the call to chapiClient.client.DoJSON().  If the request fails, and an
+// error was returned by the CHAPI server, that error is returned instead.
+func (chapiClient *Client) chapiClientDoJSON(r *connectivity.Request) (int, error) {
+
+	// Start by calling submitting the request to the CHAPI endpoint
+	statusCode, err := chapiClient.client.DoJSON(r)
+
+	if err != nil {
+		//  If we received an error from the CHAPI server, use that error object
+		if cerror, ok := r.ResponseError.(*Response); ok && (cerror.Err != nil) {
+			log.Error("CHAPI Error : ", cerror.Err)
+			return 0, cerror.Err
+		}
+
+		// For all other errors, return the connectivity error
+		log.Error("Connectivity Error : ", err)
+		return 0, err
+	}
+
+	// CHAPI request was successful; return the HTTP status code with no error
+	return statusCode, nil
+}
+
+// appendQuerySerialNumber appends a serial number query to the given URI
+func (chapiClient *Client) appendQuerySerialNumber(uri string, serialNumber string) string {
+	return chapiClient.appendQuery(uri, querySerialNumber, serialNumber)
+}
+
+// appendQuerySerialNumber appends a mount ID query to the given URI
+func (chapiClient *Client) appendQueryMountPointID(uri string, serialNumber string) string {
+	return chapiClient.appendQuery(uri, queryMountID, serialNumber)
+}
+
+// appendQuery appends the key key/value query to the given URI
+func (chapiClient *Client) appendQuery(uri string, key string, value string) string {
+	// Don't append query if value is empty
+	if value == "" {
+		return uri
+	}
+
+	// First query appended or adding to existing query?
+	if strings.Contains(uri, "?") {
+		uri += "&"
+	} else {
+		uri += "?"
+	}
+
+	// Append and return the query
+	uri += (key + "=" + value)
+	return uri
+}

--- a/chapi2/chapiclient/chapiclient.go
+++ b/chapi2/chapiclient/chapiclient.go
@@ -341,9 +341,9 @@ func (chapiClient *Client) appendQuerySerialNumber(uri string, serialNumber stri
 	return chapiClient.appendQuery(uri, querySerialNumber, serialNumber)
 }
 
-// appendQuerySerialNumber appends a mount ID query to the given URI
-func (chapiClient *Client) appendQueryMountPointID(uri string, serialNumber string) string {
-	return chapiClient.appendQuery(uri, queryMountID, serialNumber)
+// appendQueryMountPointID appends a mount ID query to the given URI
+func (chapiClient *Client) appendQueryMountPointID(uri string, mountPointID string) string {
+	return chapiClient.appendQuery(uri, queryMountID, mountPointID)
 }
 
 // appendQuery appends the key key/value query to the given URI

--- a/chapi2/chapiclient/chapiclient_linux.go
+++ b/chapi2/chapiclient/chapiclient_linux.go
@@ -1,0 +1,70 @@
+// (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+
+package chapiclient
+
+import (
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/hpe-storage/common-host-libs/chapi2"
+	"github.com/hpe-storage/common-host-libs/connectivity"
+	log "github.com/hpe-storage/common-host-libs/logger"
+)
+
+// Client contains the Linux specific Client properties
+type Client struct {
+	ClientBase        // Embedded platform independent struct
+	socket     string // Socket name on which chapid is listening
+}
+
+// newChapiClient is the platform specific handler for the NewChapiClient method
+func newChapiClient() (*Client, error) {
+	return NewChapiSocketClientWithTimeout(nil)
+}
+
+// newChapiClientWithTimeout is the platform specific handler for the NewChapiClientWithTimeout method
+func newChapiClientWithTimeout(timeout time.Duration) (*Client, error) {
+	return NewChapiSocketClientWithTimeout(&timeout)
+}
+
+// NewChapiClientWithTimeout returns the CHAPI client object, using Linux sockets, that is used
+// to communicate with the  CHAPI server over HTTP.  A custom timeout value is supported.
+func NewChapiSocketClientWithTimeout(timeout *time.Duration) (chapiClient *Client, err error) {
+
+	// Get the socket name
+	socketName := GetSocketName()
+
+	// Setup the CHAPI client object with a timeout value (if provided)
+	var socketClient *connectivity.Client
+	if timeout == nil {
+		log.Traceln("Setting up CHAPI client with socket ", socketName)
+		socketClient = connectivity.NewSocketClient(socketName)
+	} else {
+		log.Traceln("Setting up CHAPI client with socket ", socketName, " and timeout ", timeout)
+		socketClient = connectivity.NewSocketClientWithTimeout(socketName, *timeout)
+	}
+
+	// Allocate and initialize a new Client object
+	chapiClient = &Client{
+		socket:     socketName,
+		ClientBase: ClientBase{client: socketClient},
+	}
+
+	// Success, return CHAPI client object
+	return chapiClient, nil
+}
+
+// GetSocketName returns unix socket name (per process)
+func GetSocketName() string {
+	if chapi2.IsChapidRunning(chapi2.ChapidSocketPath + chapi2.ChapidSocketName) {
+		return chapi2.ChapidSocketPath + chapi2.ChapidSocketName
+	}
+	return chapi2.ChapidSocketPath + chapi2.ChapidSocketName + strconv.Itoa(os.Getpid())
+}
+
+// print is the platform specific routine to dump the CHAPI client struct
+func (chapiClient *Client) print() {
+	log.Traceln("Socket : ", chapiClient.socket)
+	log.Traceln("Header : ", chapiClient.header)
+}

--- a/chapi2/chapiclient/chapiclient_util.go
+++ b/chapi2/chapiclient/chapiclient_util.go
@@ -1,0 +1,8 @@
+// (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+
+package chapiclient
+
+// chapiclient.go is used *only* for CHAPI wrapped endpoints.  Any additional CHAPI client
+// functionality, that extends the endpoint support, should be placed in this module.  For example,
+// CHAPI1 has an AttachAndMountDevice() Client method that makes use of multiple CHAPI endpoints.
+// This type of extended functionality, if needed, would be placed in this module.

--- a/chapi2/chapiclient/chapiclient_windows.go
+++ b/chapi2/chapiclient/chapiclient_windows.go
@@ -1,0 +1,183 @@
+// (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+
+package chapiclient
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hpe-storage/common-host-libs/chapi2/handler"
+	"github.com/hpe-storage/common-host-libs/chapi2/model"
+	"github.com/hpe-storage/common-host-libs/connectivity"
+	log "github.com/hpe-storage/common-host-libs/logger"
+)
+
+const (
+	// Host Endpoints (Windows specific)
+	keyFileURI = apiVersion + "/keyfile"
+)
+
+const (
+	// CHAPI will wait up to 2 minutes for a request to complete (if default timeout used)
+	defaultChapiTimeout = 2 * time.Minute
+)
+
+// Client contains the Windows specific Client properties
+type Client struct {
+	ClientBase        // Embedded platform independent struct
+	hostname   string // URL where server is running
+	port       uint64 // Port number where the server is listening
+}
+
+// newChapiClient is the platform specific handler for the NewChapiClient method
+func newChapiClient() (*Client, error) {
+	return NewChapiWindowsClient("", nil)
+}
+
+// newChapiClientWithTimeout is the platform specific handler for the NewChapiClientWithTimeout method
+func newChapiClientWithTimeout(timeout time.Duration) (*Client, error) {
+	return NewChapiWindowsClient("", &timeout)
+}
+
+// NewChapiWindowsClient returns the a CHAPI Client object that this client uses to communicate with
+// the CHAPI server.  The following input parameters are available:
+//
+//		chapiFolder		Folder where CHAPI binary is located.  CHAPI for Windows stores its TCP/IP
+//						port value in a text file in this folder.  If an empty string is passed in
+//						as input, this routine uses the currently running executable's folder.  If
+//						your binary is installed alongside the CHAPI for Windows server, you can
+//						simply pass in an empty string.
+//
+//		timeout			This parameter specifies how long CHAPI will wait for the REST endpoint to
+//						complete a request.  If 'nil' is passed in, an internal default value will
+//						be used.
+func NewChapiWindowsClient(chapiFolder string, timeout *time.Duration) (chapiClient *Client, err error) {
+
+	// If no CHAPI executable folder path is provided, use the running executable's path
+	if chapiFolder == "" {
+		if chapiFolder, err = os.Executable(); err != nil {
+			return nil, err
+		}
+		chapiFolder = filepath.Dir(chapiFolder)
+	}
+
+	// Get the full path to the CHAPI port text file
+	chapiPortFilePath := filepath.Join(chapiFolder, handler.ChapiPortFileName)
+	log.Tracef("CHAPI port filepath = %v", chapiPortFilePath)
+
+	// Read in the CHAPI port text file
+	buf, err := ioutil.ReadFile(chapiPortFilePath)
+	if err != nil {
+		log.Errorf("Failed to read CHAPI port file, err=%v", err)
+		return nil, err
+	}
+
+	// Convert CHAPI port text a buffer to a string
+	chapiPort := strings.TrimSuffix(string(buf), "\r\n")
+	log.Tracef("CHAPI port obtained is '%v' from file '%v'", chapiPort, chapiPortFilePath)
+
+	// Convert CHAPI port text to a uint64
+	port, err := strconv.ParseUint(chapiPort, 10, 64)
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+
+	// Allocate a CHAPI HTTP Client object so we can send endpoint requests
+	chapiClient, err = newChapiHTTPClientWithTimeout("", port, timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	// Obtain access/secret key and insert as HTTP headers
+	accessKey, err := chapiClient.GetAccessKey()
+	if err != nil {
+		log.Errorf("Failed to get host access-key, err=%v", err)
+		return nil, err
+	}
+
+	// Add the HTTP header
+	header := map[string]string{"CHAPILocalAccessKey": accessKey}
+	chapiClient.addHeader(header)
+
+	// Return the initialize CHAPI Client object
+	return chapiClient, nil
+}
+
+// newChapiHTTPClientWithTimeout creates a CHAPI http client using a specified timeout
+func newChapiHTTPClientWithTimeout(hostName string, port uint64, timeout *time.Duration) (*Client, error) {
+
+	// If no hostName provided, default to the local host (e.g. http://127.0.0.1)
+	if hostName == "" {
+		hostName = "http://127.0.0.1"
+	}
+
+	// If no timeout specified, use the default timeout
+	chapiTimeout := defaultChapiTimeout
+	if timeout != nil {
+		chapiTimeout = *timeout
+	}
+
+	// Format the URL as "hostname:port"
+	hostURL := fmt.Sprintf("%v:%v", hostName, port)
+	log.Tracef("Setting up CHAPI client, hostURL=%v, timeout=%v", hostURL, chapiTimeout)
+
+	// Initialize an HTTP client with the specified timeout
+	httpClient := connectivity.NewHTTPClientWithTimeout(hostURL, chapiTimeout)
+
+	// Initialize a CHAPI client object with the initialized HTTP client, host name, and port
+	chapiClient := &Client{
+		ClientBase: ClientBase{client: httpClient},
+		hostname:   hostName,
+		port:       port,
+	}
+
+	// Return the successfully initialized CHAPI client object
+	return chapiClient, nil
+}
+
+// print is the platform specific routine to dump the CHAPI client struct
+func (chapiClient *Client) print() {
+	log.Traceln("Hostname : ", chapiClient.hostname)
+	log.Traceln("Port     : ", chapiClient.port)
+	log.Traceln("Header   : ", chapiClient.header)
+}
+
+// GetAccessKey will retrieve the access key from the host
+func (chapiClient *Client) GetAccessKey() (accessKey string, err error) {
+	log.Trace(">>>>> GetAccessKey called")
+	defer log.Trace("<<<<< GetAccessKey")
+
+	// Initialize CHAPI response object, submit request to specified endpoint, return status
+	var accessKeyPath *model.KeyFileInfo
+	chapiResp := Response{Data: &accessKeyPath, Err: nil}
+	if _, err = chapiClient.chapiClientDoJSON(&connectivity.Request{Action: "GET", Path: keyFileURI, Header: chapiClient.header, Payload: nil, Response: &chapiResp, ResponseError: &chapiResp}); err != nil {
+		return "", err
+	}
+
+	// If for some reason the accessKeyPath is nil (should not occur), fail the request
+	if accessKeyPath == nil {
+		err = fmt.Errorf("invalid accessKeyPath object")
+		log.Error(err)
+		return "", err
+	}
+
+	// Log the access key file path
+	log.Tracef("accessKeyPath = %v", accessKeyPath.Path)
+
+	// Read the file and extract the accessKey
+	buf, err := ioutil.ReadFile(accessKeyPath.Path)
+	if err != nil {
+		return "", err
+	}
+	accessKey = strings.TrimSuffix(string(buf), "\r\n")
+	// For security, accessKey is not logged
+
+	// Success!  Return enumerated access key.
+	return accessKey, nil
+}

--- a/chapi2/handler/handler_windows.go
+++ b/chapi2/handler/handler_windows.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hpe-storage/common-host-libs/chapi2/model"
 	log "github.com/hpe-storage/common-host-libs/logger"
 	"github.com/hpe-storage/common-host-libs/windows/advapi32"
+	uuid "github.com/satori/go.uuid"
 	"golang.org/x/sys/windows"
 )
 
@@ -46,6 +47,9 @@ func init() {
 
 	// Set configDir path
 	configDir = filepath.Join(programDataPath, configRelativePath)
+
+	// Set the CHAPI key access GUID
+	chapiKeyGUID = uuid.NewV4().String()
 
 	// Set the CHAPIPort.txt and keyfile.txt paths
 	exePath, _ := os.Executable()
@@ -96,7 +100,7 @@ func validateRequestHeader(w http.ResponseWriter, r *http.Request) bool {
 			}
 
 			// If the authorization key matches, return no error
-			if val[0] == chapiKeyGUID {
+			if (val[0] != "") && (val[0] == chapiKeyGUID) {
 				// Valid token provided!
 				status = true
 			} else {

--- a/chapi2/handler/handler_windows.go
+++ b/chapi2/handler/handler_windows.go
@@ -23,7 +23,7 @@ import (
 const (
 	defaultFileSystem  = "ntfs"                 // Default file system to use
 	configRelativePath = `Nimble Storage\CHAPI` // Path appended to %ProgramData% where we store CHAPI data
-	chapiPortFileName  = "CHAPIPort.txt"        // Client reads in this file to enumerate CHAPI port
+	ChapiPortFileName  = "CHAPIPort.txt"        // Client reads in this file to enumerate CHAPI port
 	chapiKeyFileName   = "keyfile.txt"          // CHAPI for Windows authentication file
 )
 
@@ -50,7 +50,7 @@ func init() {
 	// Set the CHAPIPort.txt and keyfile.txt paths
 	exePath, _ := os.Executable()
 	exePath = filepath.Dir(exePath)
-	chapiPortFilePath = filepath.Join(exePath, chapiPortFileName)
+	chapiPortFilePath = filepath.Join(exePath, ChapiPortFileName)
 	chapiKeyFilePath = filepath.Join(exePath, chapiKeyFileName)
 }
 


### PR DESCRIPTION
* Problem:
  * Need to port CHAPI1 client package to CHAPI2
* Implementation:
  * handler_windows.go
    * Changed chapiPortFileName to ChapiPortFileName so that string is accessible to other packages (e.g. CHAPI client)
  * chapiclient.go
    * Ported CHAPI1 code to CHAPI2
    * NewChapiClient() and NewChapiClientWithTimeout() are platform independent methods to create a new CHAPI Client object
    * **Only** wrap CHAPI2 endpoints in this module
    * Simplified all endpoint handlers by wrapping chapiClient.client.DoJSON in a new chapiClient.chapiClientDoJSON() function (shared/common error handling)
    * Updated Response object to expect a cerrors.ChapiError object instead of a generic error
    * Compilation will fail if Client object does not support CHAPI2's Driver interface (i.e. keep parity between client and server)
  * chapiclient_linux.go
    * Provide Linux specific Client object creation methods
    * All Socket methods are in this Linux module since they're not applicable to Windows
  * chapiclient_windows.go
    * Provide Windows specific Client object creation methods
    * All HTTP port methods are in this Windows module since they're not applicable to Linux
  * chapiclient_util.go
    * Created a util stub module to add any support routines that are intended to extend the capabilities beyond the CHAPI endpoints
* Testing:
  * Successfully built Linux and Windows binaries
  * Created a chapid resident service for Windows and exercised available endpoints using chapiclient package
  * Linux testing and final implementation pending
* Reviewers:
  * @shivamerla, @suneeth51
* Bug: N/A