### PR TITLE
chapi2: Miscellaneous enhancements

### DIFF
--- a/chapi2/driver/driver.go
+++ b/chapi2/driver/driver.go
@@ -126,13 +126,7 @@ func (driver *ChapiServer) GetHostInfo() (*model.Host, error) {
 	}
 	log.Infof("Domain Name - %v", domainName)
 
-	networks, err := hostPlugin.GetNetworks()
-	if err != nil {
-		return nil, cerrors.NewChapiError(err)
-	}
-	driver.logNetworks(networks)
-
-	return &model.Host{UUID: id, Name: hostName, Domain: domainName, Networks: networks}, nil
+	return &model.Host{UUID: id, Name: hostName, Domain: domainName}, nil
 }
 
 // GetHostNetworks reports the networks on this host

--- a/chapi2/model/types.go
+++ b/chapi2/model/types.go
@@ -59,11 +59,9 @@ const (
 
 // Host : Host information
 type Host struct {
-	UUID       string       `json:"id,omitempty"`         // Unique host identifier
-	Name       string       `json:"name,omitempty"`       // Host name
-	Domain     string       `json:"domain,omitempty"`     // Host domain name
-	Networks   []*Network   `json:"networks,omitempty"`   // Host network adapters
-	Initiators []*Initiator `json:"initiators,omitempty"` // Host initiators (iSCSI and/or FC)
+	UUID   string `json:"id,omitempty"`     // Unique host identifier
+	Name   string `json:"name,omitempty"`   // Host name
+	Domain string `json:"domain,omitempty"` // Host domain name
 }
 
 // Hosts returns an array of Host objects


### PR DESCRIPTION
* Problem:
  * Checking in a few miscellaneous CHAPI2 enhancements
* Implementation:
  * types.go
    * After discussions with @shivamerla, we are no longer returning the Networks and Initiators objects as part of the Host object
    * Networks and Initiators endpoints are already available to enumerate this information
    * Reduces the overhead of enumerating basic host information such as the host ID, host name, and host domain
  * driver.go
    * Updated GetHostInfo() to not return the networks object (already wasn't returning the initiators)
  * host_windows.go
    * Added error logging if net.Interfaces() fails
    * If windows.ERROR_NO_DATA is returned from the GetAdaptersInfo() Win32 API, we now return an empty NIC array with no error.  Windows maps ERROR_NO_DATA to "The pipe is being closed" which is a misleading error message.  ERROR_NO_DATA simply indicates that no NICs are present on the host.
    * If no iSCSI initiators are present on the host (e.g. FC only), we previously were failing NIC enumeration.  Updated code to allow NIC enumeration to continue without requiring iSCSI initiator enumeration to be successful.
  * wmiquery.go
    * Enhanced error handling if a WMI query fails because the WMI class is not supported.  Previous versions would fail the request but not with an optimal error code.  We now map this failing condition to windows.ERROR_NOT_SUPPORTED.
* Testing:
  * Successfully built chapid for Windows and Linux
  * Validated CHAPI2 behavior on a Windows host with no NICs
  * Validated Host endpoint only returns host ID, name, and domain
  * Validated proper behavior on a Windows host without iSCSI service available
* Reviewers:
  * @shivamerla, @suneeth51
* Bug: N/A