### PR TITLE
Makefile: remove redundant install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,6 @@ tools: ; $(info $(A1) gettools)
 	export $(GOENV) && gometalinter --install
 	@echo "$(A2) get glide"
 	go get -u github.com/Masterminds/glide
-	go install github.com/Masterminds/glide
 	@echo "$(S0)"
 
 vendup: tools; $(info $(A1) vendup)


### PR DESCRIPTION
* Problem:
  * "go install" is not necessary after a "go get"
  * "go help get" specifically states that "Get downloads the packages named by the import paths, along with their dependencies. It then installs the named packages, like 'go install'"
* Implementation:
  * Removed any redundant "go install" entries
* Testing:
  * Verified that "go get" compiles and installs the package locally
* Bug: N/A