### PR TITLE
dockerplugin: fixes for cloud volume support

### DIFF
--- a/dockerplugin/provider/nimble_provider.go
+++ b/dockerplugin/provider/nimble_provider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hpe-storage/common-host-libs/util"
 	"io/ioutil"
 	"net/http"
+	"os"
 )
 
 // struct to map all blocked keys per option
@@ -32,6 +33,14 @@ type LoginRequest struct {
 	Username string `json:"UserName,omitempty"`
 	Password string `json:"Password,omitempty"`
 	Cert     string `json:"Cert,omitempty"`
+}
+
+// IsNimblePlugin returns true if plugin type is for nimble platform
+func IsNimblePlugin() bool {
+	if os.Getenv("PLUGIN_TYPE") == "nimble" {
+		return true
+	}
+	return false
 }
 
 func getBasicContainerProviderClient(ipAddress string) *connectivity.Client {

--- a/model/types.go
+++ b/model/types.go
@@ -187,16 +187,19 @@ type Volume struct {
 	ConnectionMode string                 `json:"connection_mode,omitempty"`
 	LunID          string                 `json:"lun_id,omitempty"`
 	TargetScope    string                 `json:"target_scope,omitempty"` //GST="group", VST="volume" or empty(older array fiji etc), and no-op for FC
-	IscsiSessions  []*iscsiSession        `json:"iscsi_sessions,omitempty"`
-	FcSessions     []*fcSession           `json:"fc_sessions,omitempty"`
+	IscsiSessions  []*IscsiSession        `json:"iscsi_sessions,omitempty"`
+	FcSessions     []*FcSession           `json:"fc_sessions,omitempty"`
 }
 
-type fcSession struct {
+// FcSession info
+type FcSession struct {
 	InitiatorWwpn string `json:"initiatorWwpn,omitempty"`
 }
 
-type iscsiSession struct {
+// IscsiSession info
+type IscsiSession struct {
 	InitiatorName string `json:"initiatorName,omitempty"`
+	InitiatorIP   string `json:"initiatorIp,omitempty"`
 }
 
 // Snapshot is a snapshot of a volume

--- a/tunelinux/iscsi.go
+++ b/tunelinux/iscsi.go
@@ -409,5 +409,11 @@ func ConfigureIscsi() (err error) {
 	if err != nil {
 		return err
 	}
+
+	err = SetIscsiRecommendations()
+	if err != nil {
+		return err
+	}
+
 	return nil
 }


### PR DESCRIPTION
* Problem:
  * inUse flag was not added for cloud volumes to handle fencing
  * mountConflictDelay is not passed for cloud volumes
  * current node initiator IP addresses were not filtered at plugin itself
  * iscsi nr_sessions=4 was not being set for cloud
* Implementation:
  * added inUse response for volume properties if initiator is connected
  * added initiator IP as response for iSCSI sessions instead of IQN name for cloud
  * filter initiator IP list from user to include only current node IP's.
  * add support for user to specify either IP addresses or interface names like eth0/eth1 etc to auto scale nodes.
* Testing:
  tesed on EKS, with provisioning, node drain and pod delete.
* Review:
* Bug: