### PR TITLE
csi/chapi: don't error out on fs mismatch if fs is already created

### DIFF
--- a/linux/mount.go
+++ b/linux/mount.go
@@ -841,13 +841,8 @@ func SetupFilesystem(device *model.Device, filesystemType string) error {
 		return err
 	}
 	if fsType != "" {
-		log.Tracef("Filesystem %s already exists on the device %s", filesystemType, device.AltFullPathName)
-		// Check if the FS is same as the request. If yes, return here with success
-		if fsType == filesystemType {
-			log.Tracef("Filesystem %s already exists on the device %s", filesystemType, device.AltFullPathName)
-			return nil
-		}
-		return fmt.Errorf("Another filesystem type %s already exists on the device %s", fsType, device.AltFullPathName)
+		log.Tracef("Filesystem %s already exists on the device %s", fsType, device.AltFullPathName)
+		return nil
 	}
 
 	log.Tracef("Creating filesystem %s on device path %s", filesystemType, device.AltFullPathName)


### PR DESCRIPTION
* Problem:
  * When fsType is not provided in storageClass(valid for cloning), external provisioner
  * defaults to ext4. During nodeStage, if the cloned volume has fsType other than ext4, we
  * are erroring out and failing stage.
* Implementation:
  * During fs creation we validate the type. But if FS is already present, we can safely assume its either
  * a clone request or duplicate stage request. fsType mismatch can be ignored given that external provisioner
  * passes a defaultType in all cases if not specified in storageClass. Other option is to fetch correct fsType
  * from parent PVC/SC, but given we have cloneOf, DataSource, Snapshot types, that might not be necessary to put these
  * checks into all types in controller-plugin.
* Testing: manual test with no fsType specified in SC.
* Review: gcostea, rkumar
* Bug: https://nimblejira.nimblestorage.com/browse/NLT-