### PR TITLE
dockerplugin: Add new env PROVIDER_SERVICE for connecting to CP servi…

### DIFF
--- a/dockerplugin/provider/hpecv_provider.go
+++ b/dockerplugin/provider/hpecv_provider.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	defaultHpecvProviderPort   = "8090"
-	defaultHpecvProviderPortal = "us.hpecloudvolumes.com"
+	defaultHpecvProviderPortal = "cloudvolumes.hpe.com"
 )
 
 //IsHPECloudVolumesPlugin returns true if plugin type is hpecv

--- a/dockerplugin/provider/provider.go
+++ b/dockerplugin/provider/provider.go
@@ -62,6 +62,8 @@ const (
 	// env params
 	// EnvIP represents provider IP env
 	EnvIP = "PROVIDER_IP"
+	// EnvService represents service name when provider running as k8s service
+	EnvService = "PROVIDER_SERVICE"
 	// EnvUsername represents provider username env
 	EnvUsername = "PROVIDER_USERNAME"
 	// EnvPassword represents provider password env
@@ -144,6 +146,14 @@ func GetProviderURI(defaultProviderPortal, defaultProviderPort, basePath string)
 
 	if envport := os.Getenv(EnvPort); envport != "" {
 		port = envport
+	}
+
+	// if service name is provided, then handle container-provider running as k8s service
+	if envService := os.Getenv(EnvService); envService != "" {
+		// override with service name
+		portal = envService
+		// allow http connection to service
+		os.Setenv(EnvInsecure, "true")
 	}
 
 	if port == "" || portal == "" {


### PR DESCRIPTION
…ce on k8s

* Problem:
  * PROVIDER_IP env is used by other docker plugins currently, however, PROVIDER_SERVICE
  * can be used to specify the service name if running in k8s. Also http connection is required
  * for service running in same cluster from the plugin
* Implementation:
  * Use PROVIDER_SERVICE env to connect to CP service and enable INSECURE mode for http connection
* Testing:
* Review: rkumar, sbyadarahalli, gcostea
* Bug: https://nimblejira.nimblestorage.com/browse/NLT-
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>