### PR TITLE
Windows plugin listens on two ports which is not in parity with linux. Fixed it

### DIFF
--- a/dockerplugin/dockerplugin_windows.go
+++ b/dockerplugin/dockerplugin_windows.go
@@ -12,7 +12,7 @@ func RunNimbledockerd(c chan error, version string) (err error) {
 	// version from build process
 	plugin.Version = version
 	// create listener for the socket
-	localListener, globalListener, err := plugin.PreparePluginSocket()
+	listener, err := plugin.PreparePluginSocket()
 	if err != nil {
 		return err
 	}
@@ -37,13 +37,10 @@ func RunNimbledockerd(c chan error, version string) (err error) {
 	// since windows doesnt support K8s yet.
 	//plugin.InitializeDeleteConflictDelay()
 
-	// listen on the local port
-	localRouter := NewRouter()
-	// listen on the global port
-	globalRouter := NewRouter()
-	//use channel to listen to local port
-	go runNimbledockerd(localListener, localRouter, c)
-	//use channel to listen to global port
-	go runNimbledockerd(globalListener, globalRouter, c)
+	// listen on the http port
+	router := NewRouter()
+
+	//use channel to listen to multiple ports simultaneously
+	go runNimbledockerd(listener, router, c)
 	return nil
 }


### PR DESCRIPTION
Bug DW-84 - Docker volumes created in other hosts are listed twice during volume list
Fix : 
Windows plugin listens on two ports which is a deviation from the Linux plugin where it listen on a single socket, it causes an issue with a windows plugin where the global volume started listing twice, one for local and one for global nimble driver. Modified the _windows.go code to listen only on single port. 