### PR TITLE
While mounting snapshots, XFS fails with duplicate FS UUID, avoid

### DIFF
--- a/linux/mount.go
+++ b/linux/mount.go
@@ -562,8 +562,15 @@ func performMount(devPath string, mountPoint string, options []string) (*model.M
 	for {
 		_, rc, err = util.ExecCommandOutput(mountCommand, args)
 		if err != nil || rc != 0 {
-			// retry on error
-			if try < 5 {
+			// if failed due to duplicate FS UUID(snapshot), attempt mount with no-uuid check option
+			if rc == mountUUIDErr {
+				log.Infof("mount failed for dev %s with rc=%d(duplicate uuid), trying again with no uuid option", devPath, mountUUIDErr)
+				_, _, err = util.ExecCommandOutput(mountCommand, []string{"-o", "nouuid", devPath, mountPoint})
+				if err != nil {
+					return nil, err
+				}
+			} else if try < 5 {
+				// retry on other generic errors
 				try++
 				log.Debugf("mount not yet complete with err :%s rc %d.. will retry", err.Error(), rc)
 				time.Sleep(time.Duration(try) * time.Second)
@@ -571,16 +578,6 @@ func performMount(devPath string, mountPoint string, options []string) (*model.M
 			}
 		}
 		break
-	}
-	if err != nil {
-		if rc != mountUUIDErr {
-			return nil, err
-		}
-		log.Trace("performMount failed with rc=" + strconv.Itoa(mountUUIDErr) + " trying again with no uuid option")
-		_, _, err = util.ExecCommandOutput(mountCommand, []string{"-o", "nouuid", devPath, mountPoint})
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	// verify that mount is successful

--- a/linux/mount.go
+++ b/linux/mount.go
@@ -579,6 +579,9 @@ func performMount(devPath string, mountPoint string, options []string) (*model.M
 		}
 		break
 	}
+	if err != nil {
+		return nil, err
+	}
 
 	// verify that mount is successful
 	err = verifyMount(devPath, mountPoint)


### PR DESCRIPTION
retries in that case and mount with no-uuid option directly
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>