### PR TITLE
chapi: Add ping test before iscsi login to avoid timeout errors

### DIFF
--- a/linux/iscsi.go
+++ b/linux/iscsi.go
@@ -201,7 +201,7 @@ func isReachable(initiatorIP, targetIP string) (reachable bool, err error) {
 		pinger.Stop()
 	}
 
-	// Perform the ping test; if we received any ICMP packet back, add the IT nexus to the return map
+	// Perform the ping test; if we received any ICMP packet back, stop the test
 	log.Tracef("PING %s --> (%s)", initiatorIP, pinger.Addr())
 	pinger.Run()
 

--- a/linux/iscsi.go
+++ b/linux/iscsi.go
@@ -7,11 +7,13 @@ import (
 	log "github.com/hpe-storage/common-host-libs/logger"
 	"github.com/hpe-storage/common-host-libs/model"
 	"github.com/hpe-storage/common-host-libs/util"
+	ping "github.com/sparrc/go-ping"
 	"io/ioutil"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const (
@@ -44,6 +46,9 @@ const (
 	iscsiHostScanPathFormat = "/sys/class/scsi_host/%s/scan"
 	alreadyPresent          = "already present"
 	endPointNotConnected    = "transport endpoint is not connected"
+	PingCount               = 5
+	PingInterval            = 10 * time.Millisecond
+	PingTimeout             = 5 * time.Second
 )
 
 //type of Scope (volume, group)
@@ -166,6 +171,47 @@ func loginToTarget(targets model.IscsiTargets, targetIqn string, ifaces []*model
 	return nil
 }
 
+func isReachable(initiatorIP, targetIP string) (reachable bool, err error) {
+	// Allocate a new ICMP ping object
+	pinger, err := ping.NewPinger(targetIP)
+	if err != nil {
+		log.Errorf("NewPinger creation failure, err=%v", err)
+		return false, err
+	}
+
+	// Send a "privileged" raw ICMP ping
+	pinger.SetPrivileged(true)
+
+	// Ping target from initiatorPort
+	pinger.Source = initiatorIP
+
+	// Count tells pinger to stop after sending (and receiving) Count echo packets
+	pinger.Count = PingCount
+
+	// Interval is the wait time between each packet sent
+	pinger.Interval = PingInterval
+
+	// Timeout specifies a timeout before ping exits, regardless of how many packets have been received
+	pinger.Timeout = PingTimeout
+
+	pinger.OnRecv = func(pkt *ping.Packet) {
+		log.Tracef("Received %d bytes from %s: icmp_seq=%d time=%v ttl=%v\n",
+			pkt.Nbytes, pkt.Addr, pkt.Seq, pkt.Rtt, pkt.Ttl)
+		reachable = true
+		pinger.Stop()
+	}
+
+	// Perform the ping test; if we received any ICMP packet back, add the IT nexus to the return map
+	log.Tracef("PING %s --> (%s)", initiatorIP, pinger.Addr())
+	pinger.Run()
+
+	if !reachable {
+		log.Errorf("PING FAILED: %s --> (%s)", initiatorIP, pinger.Addr())
+		return false, nil
+	}
+	return true, nil
+}
+
 func updateConnectionMode(target *model.IscsiTarget, targets model.IscsiTargets, connectionMode string) {
 	log.Tracef("updateConnectionMode called for target %s mode %s", target.Name, connectionMode)
 	if !(connectionMode == "automatic" || connectionMode == "manual") {
@@ -221,6 +267,17 @@ func addTarget(target *model.IscsiTarget, ifaces []*model.Iface) (err error) {
 	args := []string{"--mode", "node", "--targetname", target.Name, "--login"}
 	if len(ifaces) > 0 {
 		for _, iface := range ifaces {
+			// verify if the target is reachable from this interface
+			reachable, err := isReachable(iface.Network.AddressV4, target.Address)
+			if err != nil {
+				log.Warnf("failed to run ping test from %s --> (%s)", iface.Network.AddressV4, target.Address)
+				// if we cannot issue ping for some reason, proceed with iscsi login
+				reachable = true
+			}
+			if !reachable {
+				log.Errorf("ping test failed from %s --> (%s), skipping iscsi login on this portal to %s", iface.Network.AddressV4, target.Address, target.Name)
+				continue
+			}
 			// login using each iface bound
 			ifaceArgs := append(args, "-I")
 			ifaceArgs = append(ifaceArgs, iface.Name)


### PR DESCRIPTION
* Problem:
  * If the target is not reachable from some interfaces, then iscsi login will
  * take long time 120s before timeout. This causes long delay during device
  * discovery
* Implementation:
  * Add simple ping test before iSCSI login. Currently this is added only if iscsi interfaces
  * are defined(cloud).
* Testing: Tested mount with multiple volumes on ec2 instance
* Review: gcostea, rkumar, sbyadarahalli
* Bug: https://nimblejira.nimblestorage.com/browse/NLT-
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>