### PR TITLE
Added custom timeout value for mountConfictDealy as it is causing doc…

### DIFF
--- a/dockerplugin/handler/mount.go
+++ b/dockerplugin/handler/mount.go
@@ -6,18 +6,19 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/hpe-storage/common-host-libs/chapi"
-	"github.com/hpe-storage/common-host-libs/connectivity"
-	"github.com/hpe-storage/common-host-libs/dockerplugin/plugin"
-	"github.com/hpe-storage/common-host-libs/dockerplugin/provider"
-	log "github.com/hpe-storage/common-host-libs/logger"
-	"github.com/hpe-storage/common-host-libs/model"
 	"net/http"
 	"os"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/hpe-storage/common-host-libs/chapi"
+	"github.com/hpe-storage/common-host-libs/connectivity"
+	"github.com/hpe-storage/common-host-libs/dockerplugin/plugin"
+	"github.com/hpe-storage/common-host-libs/dockerplugin/provider"
+	log "github.com/hpe-storage/common-host-libs/logger"
+	"github.com/hpe-storage/common-host-libs/model"
 )
 
 const (
@@ -100,7 +101,7 @@ func VolumeDriverMount(w http.ResponseWriter, r *http.Request) {
 	}
 
 	//2. this method does poll to container provider to check if other hosts are attached until mountConflictDelay
-	processMountConflictDelay(pluginReq.Name, providerClient, pluginReq, plugin.MountConflictDelay)
+	processMountConflictDelay(pluginReq.Name, providerClient, pluginReq, plugin.GetMountConflictDealy())
 
 	mapMutex.Lock(pluginReq.Name)
 	log.Debugf("taken lock for volume %s in Mount", pluginReq.Name)

--- a/dockerplugin/plugin/plugin.go
+++ b/dockerplugin/plugin/plugin.go
@@ -30,6 +30,9 @@ const (
 	DefaultDeleteConflictDelay = 150
 	// MountConflictDelayKey represents the key name for wait on conflicts for mount
 	MountConflictDelayKey = "mountConflictDelay"
+
+	//EnvMountConflictDelay represents custome mount conflict timeout value
+	EnvMountConflictDelay = "MOUNT_CONFLICT_DELAY"
 	// DefaultMountConflictDelay represents the default delay to wait on conflicts during mount
 	DefaultMountConflictDelay = 120
 )
@@ -40,6 +43,7 @@ var (
 	configLock         sync.Mutex
 	// Version of Plugin
 	Version = "dev"
+
 	// DeleteConflictDelay represent conflict delay to wait during remove
 	DeleteConflictDelay = DefaultDeleteConflictDelay
 	// MountConflictDelay represent conflict delay to wait during mount
@@ -127,6 +131,20 @@ func IsManagedPlugin() bool {
 		return true
 	}
 	return false
+}
+
+// GetMountConflictDealy returns mount conflict time out value
+func GetMountConflictDealy() int {
+	conflictDelay := os.Getenv(EnvMountConflictDelay)
+	if conflictDelay != "" {
+		timeout, err := strconv.Atoi(conflictDelay)
+		if err != nil {
+			log.Error("unable to read mountConflictDealy from environment, ", err.Error())
+		} else {
+			MountConflictDelay = timeout
+		}
+	}
+	return MountConflictDelay
 }
 
 // IsLocalScopeDriver return true if its a local scoped driver, false otherwise


### PR DESCRIPTION
Problem : DW-67, Mounting the volume into multiple containers fail. 
Fix : 
The mountConflictDealy default time out value is 2 min which coincides with  docker CLI timeout value. In this scenario when the volume is already mounted to one container and, the user tries to mount the same volume to second container, the plugin mount workflows always goes in to processMountConflictDealy and wait for 2mins (default hardcoded timeout value) which results into docker cli (mount workflow ) almost always getting timed out with the following errors 
_

"C:\Program Files\Docker\docker.exe: Error response from daemon: error while mounting volume 'C:\ProgramData\hpe-storage-mounts\testvol16server\': Post http://localhost:8080/VolumeDriver.Mount: context deadline exceeded"

_  

There is no option to increase the timeout value for docker CLI. So to fix this I have introduced "MOUNT_CONFLICT_DELAY" which is optional. If the user sets this env, the default mountconflictdelay value is overwritten. 





Signed-off-by: vidhut-kumar-singh <vidhut-kumar.singh@hpe.com>