### PR TITLE
UnMount workflow bailout if chapi returns error on Windows, added str…

### DIFF
--- a/dockerplugin/handler/unmount.go
+++ b/dockerplugin/handler/unmount.go
@@ -5,12 +5,14 @@ package handler
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
+	"strings"
+
 	"github.com/hpe-storage/common-host-libs/chapi"
 	"github.com/hpe-storage/common-host-libs/connectivity"
 	"github.com/hpe-storage/common-host-libs/dockerplugin/provider"
 	log "github.com/hpe-storage/common-host-libs/logger"
 	"github.com/hpe-storage/common-host-libs/model"
-	"net/http"
 )
 
 var (
@@ -123,9 +125,14 @@ func VolumeDriverUnmount(w http.ResponseWriter, r *http.Request) {
 	if device != nil {
 		err = chapiClient.DeleteDevice(device)
 		if err != nil {
-			dr = DriverResponse{Err: err.Error()}
-			json.NewEncoder(w).Encode(dr)
-			return
+			if !strings.Contains(err.Error(), "object was not found on the system") {
+				dr = DriverResponse{Err: err.Error()}
+				json.NewEncoder(w).Encode(dr)
+				return
+			} else {
+				log.Errorln("Delete device called failed, chapi returned ", err.Error())
+			}
+
 		}
 	}
 


### PR DESCRIPTION
Bug : NWT-3746

Chapi Unmount wokrflow hard fails during DeviceDelete call since Windows CHAPI returns "404 Not Found" error. The code detachdevice never gets executed and the destroyondetach feature never works . 
Since the device is already unmounted and it is not visible to the host , so it would be ok to ignore the 404 Not Found error with Windows CHAPI . 

Signed-off-by: vidhut-kumar-singh <vidhut-kumar.singh@hpe.com>