### PR TITLE
DW-140 

### DIFF
--- a/dockerplugin/handler/mount.go
+++ b/dockerplugin/handler/mount.go
@@ -465,7 +465,7 @@ func cleanupStaleMounts(containerProviderClient *connectivity.Client, chapiClien
 	log.Tracef("volumeInfo is %+v", volumeInfo)
 	// get the mounts of the volumes's serial number
 	_ = chapiClient.GetMounts(&respMount, plugin.GetDeviceSerialNumber(volumeInfo.SerialNumber))
-	if respMount == nil {
+	if respMount == nil || len(respMount) == 0 {
 		log.Tracef("no existing stale mounts found for volume %s, continue with mount", volumeInfo.Name)
 		return
 	}

--- a/dockerplugin/handler/unmount.go
+++ b/dockerplugin/handler/unmount.go
@@ -5,12 +5,14 @@ package handler
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
+	"strings"
+
 	"github.com/hpe-storage/common-host-libs/chapi"
 	"github.com/hpe-storage/common-host-libs/connectivity"
 	"github.com/hpe-storage/common-host-libs/dockerplugin/provider"
 	log "github.com/hpe-storage/common-host-libs/logger"
 	"github.com/hpe-storage/common-host-libs/model"
-	"net/http"
 )
 
 var (
@@ -123,9 +125,14 @@ func VolumeDriverUnmount(w http.ResponseWriter, r *http.Request) {
 	if device != nil {
 		err = chapiClient.DeleteDevice(device)
 		if err != nil {
-			dr = DriverResponse{Err: err.Error()}
-			json.NewEncoder(w).Encode(dr)
-			return
+			if !strings.Contains(err.Error(), "object was not found on the system") {
+				dr = DriverResponse{Err: err.Error()}
+				json.NewEncoder(w).Encode(dr)
+				return
+			} else {
+				log.Errorln("Delete device called failed, chapi returned ", err.Error())
+			}
+
 		}
 	}
 


### PR DESCRIPTION
Problem : 
The dockerplugind thread crashes in cleanStaleMount() call . 

Fix : 
respMount is a double pointer which can be a valid pointer with empty array. Handled the condition properly. 