### PR TITLE
Fix : mountConflictDealy timeout value defined in volume-driver.json …

### DIFF
--- a/dockerplugin/dockerplugin_windows.go
+++ b/dockerplugin/dockerplugin_windows.go
@@ -37,6 +37,8 @@ func RunNimbledockerd(c chan error, version string) (err error) {
 	// since windows doesnt support K8s yet.
 	//plugin.InitializeDeleteConflictDelay()
 
+	// Control the mountConflictDelay behavior as it is causing default timeout 120 sec.
+	plugin.InitializeMountConflictDelay()
 	// listen on the http port
 	router := NewRouter()
 


### PR DESCRIPTION
Problem:
There is a bug in the plugin where it doesn't honour the user-defined "mountConflictDelay" in volume-driver.json file. It always defaults to 120 second as this is default hardcoded value in the source code. This bug also exists with Linux plugin as per the code. 

Fix : 
To fix this, i am invoking plugin.InitializeMountConflictDealy() which basically updates the mountConflictDealy timeout value from volume-driver.json if define. 
Same fix can be done for Linux plugin as this is only applicable for Windows plugin . 


Signed-off-by: vidhut-kumar-singh <vidhut-kumar.singh@hpe.com>