### PR TITLE
FCSessions and IscsiSession tags are broken between fiji and GOA onwards

### DIFF
--- a/dockerplugin/handler/handler.go
+++ b/dockerplugin/handler/handler.go
@@ -3,13 +3,14 @@
 package handler
 
 import (
+	"net/http"
+	"regexp"
+
 	"github.com/hpe-storage/common-host-libs/concurrent"
 	"github.com/hpe-storage/common-host-libs/dockerplugin/plugin"
 	"github.com/hpe-storage/common-host-libs/dockerplugin/provider"
 	log "github.com/hpe-storage/common-host-libs/logger"
 	"github.com/hpe-storage/common-host-libs/model"
-	"net/http"
-	"regexp"
 )
 
 const (
@@ -109,6 +110,12 @@ type CreateResponse struct {
 type VolumeResponse struct {
 	Volume *model.Volume `json:"volume,omitempty"`
 	Err    string        `json:"Err"`
+}
+
+//FijiVolumeResponse : Volume response struct
+type FijiVolumeResponse struct {
+	Volume *model.FijiVolume `json:"volume,omitempty"`
+	Err    string            `json:"Err"`
 }
 
 //VolumeUnmountResponse : Volume unmount response

--- a/model/types.go
+++ b/model/types.go
@@ -202,6 +202,48 @@ type IscsiSession struct {
 	InitiatorIP   string `json:"initiator_ip_addr,omitempty"`
 }
 
+// FijiVolume : Thin version of Volume object for Host side
+//nolint: dupl
+type FijiVolume struct {
+	ID             string                 `json:"id,omitempty"`
+	Name           string                 `json:"name,omitempty"`
+	Size           int64                  `json:"size,omitempty"` // size in bytes
+	Description    string                 `json:"description,omitempty"`
+	InUse          bool                   `json:"in_use,omitempty"` // deprecated for published in the CSP implementation
+	Published      bool                   `json:"published,omitempty"`
+	BaseSnapID     string                 `json:"base_snapshot_id,omitempty"`
+	ParentVolID    string                 `json:"parent_volume_id,omitempty"`
+	Clone          bool                   `json:"clone,omitempty"`
+	Config         map[string]interface{} `json:"config,omitempty"`
+	Metadata       []*KeyValue            `json:"metadata,omitempty"`
+	SerialNumber   string                 `json:"serial_number,omitempty"`
+	AccessProtocol string                 `json:"access_protocol,omitempty"`
+	Iqn            string                 `json:"iqn,omitempty"`
+	DiscoveryIP    string                 `json:"discovery_ip,omitempty"` // this field needs to be moved out ?
+	MountPoint     string                 `json:"Mountpoint,omitempty"`
+	Status         map[string]interface{} `json:"status,omitempty"` // interface so that we can map any number of arguments
+	Chap           *ChapInfo              `json:"chap_info,omitempty"`
+	Networks       []*Network             `json:"networks,omitempty"`
+	ConnectionMode string                 `json:"connection_mode,omitempty"`
+	LunID          string                 `json:"lun_id,omitempty"`
+	TargetScope    string                 `json:"target_scope,omitempty"` //GST="group", VST="volume" or empty(older array fiji etc), and no-op for FC
+
+	//Backward compatibility fix.
+	FijiIscsiSessions []*FijiIscsiSession `json:"iscsi_sessions,omitempty"`
+	FijiFcSessions    []*FijiFcSession    `json:"fc_sessions,omitempty"`
+}
+
+// FijiFcSession info
+type FijiFcSession struct {
+	InitiatorWwpn string `json:"initiatorWwpn,omitempty"`
+}
+
+// FijiIscsiSession info
+type FijiIscsiSession struct {
+	InitiatorName string `json:"initiatorName,omitempty"`
+	InitiatorIP   string `json:"initiatorIp,omitempty"`
+}
+
 // Snapshot is a snapshot of a volume
 type Snapshot struct {
 	ID           string                 `json:"id,omitempty"`
@@ -244,9 +286,9 @@ type BlockDeviceAccessInfo struct {
 
 // IscsiAccessInfo contains the fields necessary for iSCSI access
 type IscsiAccessInfo struct {
-	DiscoveryIPs []string `json:"discovery_ips,omitempty"`
-	ChapUser     string   `json:"chap_user,omitempty"`
-	ChapPassword string   `json:"chap_password,omitempty"`
+	DiscoveryIP  string `json:"discovery_ip,omitempty"`
+	ChapUser     string `json:"chap_user,omitempty"`
+	ChapPassword string `json:"chap_password,omitempty"`
 }
 
 // VirtualDeviceAccessInfo contains the required data to access a virtual device


### PR DESCRIPTION
Container-Provider backward compatibility is broken between fiji.8 and GOA , HANA etc for 
ISCSI and FC sessions 
Fiji.8 Array has following tags :
 
// FcSession info
type FijiFcSession struct {
                InitiatorWwpn string `json:"initiatorWwpn,omitempty"`
}
 
// IscsiSession info
type FijiIscsiSession struct {
                InitiatorName string `json:"initiatorName,omitempty"`
                InitiatorIP   string `json:"initiatorIp,omitempty"`
}
 
GOA Array has following tags :
 
// FcSession info
type FcSession struct {
                InitiatorWwpn string `json:"initiator_wwpn,omitempty"`
}
 
// IscsiSession info
type IscsiSession struct {
                InitiatorName string `json:"initiator_name,omitempty"`
                InitiatorIP   string `json:"initiator_ip_addr,omitempty"`
} 


Fix : 
I handled it in plugin by checking if it returns empty() value for session tags , if it does it means NOS is old . 


Signed-off-by: vidhut-kumar-singh <vidhut-kumar.singh@hpe.com>