### PR TITLE
dockerplugin: fix issue with reporting of iscsi/fc session info between fiji/goa

### DIFF
--- a/dockerplugin/handler/mount.go
+++ b/dockerplugin/handler/mount.go
@@ -597,7 +597,7 @@ func isCurrentHostAttachedIscsi(volume *model.Volume, pluginReq *PluginRequest) 
 
 	for _, iscsiSession := range volume.IscsiSessions {
 		for _, iscsiInit := range iscsiInits {
-			if strings.TrimSpace(iscsiSession.InitiatorName) == strings.TrimSpace(iscsiInit) {
+			if strings.TrimSpace(iscsiSession.InitiatorNameStr()) == strings.TrimSpace(iscsiInit) {
 				log.Debugf("host iscsi initiator %s matched volume iscsi session", iscsiInit)
 				return true
 			}
@@ -634,7 +634,7 @@ func isCurrentHostAttachedFC(volume *model.Volume, pluginReq *PluginRequest) boo
 
 	for _, fcSession := range volume.FcSessions {
 		for _, fcInit := range fcInits {
-			if strings.TrimSpace(strings.Replace(fcSession.InitiatorWwpn, ":", "", -1)) == strings.TrimSpace(fcInit) {
+			if strings.TrimSpace(strings.Replace(fcSession.InitiatorWwpnStr(), ":", "", -1)) == strings.TrimSpace(fcInit) {
 				log.Infof("host initiator %s matched volume FC sessions %s", fcInit, fcSession)
 				return true
 			}

--- a/model/types.go
+++ b/model/types.go
@@ -191,15 +191,32 @@ type Volume struct {
 	FcSessions     []*FcSession           `json:"fc_sessions,omitempty"`
 }
 
+// Workaround NOS 5.0.x vs 5.1.x responses with different case
 // FcSession info
 type FcSession struct {
-	InitiatorWwpn string `json:"initiator_wwpn,omitempty"`
+	InitiatorWwpn       string `json:"initiator_wwpn,omitempty"`
+	InitiatorWwpnLegacy string `json:"initiatorWwpn,omitempty"`
 }
 
 // IscsiSession info
 type IscsiSession struct {
-	InitiatorName string `json:"initiator_name,omitempty"`
-	InitiatorIP   string `json:"initiator_ip_addr,omitempty"`
+	InitiatorName       string `json:"initiator_name,omitempty"`
+	InitiatorNameLegacy string `json:"initiatorName,omitempty"`
+	InitiatorIP         string `json:"initiator_ip_addr,omitempty"`
+}
+
+func (s FcSession) InitiatorWwpnStr() string {
+	if s.InitiatorWwpnLegacy != "" {
+		return s.InitiatorWwpnLegacy
+	}
+	return s.InitiatorWwpn
+}
+
+func (s IscsiSession) InitiatorNameStr() string {
+	if s.InitiatorNameLegacy != "" {
+		return s.InitiatorNameLegacy
+	}
+	return s.InitiatorName
 }
 
 // Snapshot is a snapshot of a volume


### PR DESCRIPTION


* Problem:
  * Fiji rest-sdk reported iscsi/fc sessions using camelCase, while goa one reported
  * with snake_case, thus unmarhalling fails from dockerplugin.
* Implementation:
  * Add legacy attributes for iscsi/fc sessions to handle both versions.
* Testing:
* Review:gcostea, vsingh
* Bug: https://nimblejira.nimblestorage.com/browse/NLT-
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>