### PR TITLE
chapi: Add bind unmount handler

### DIFF
--- a/chapi/chapidriver.go
+++ b/chapi/chapidriver.go
@@ -18,6 +18,7 @@ type Driver interface {
 	OfflineDevice(device *model.Device) error
 	MountDevice(device *model.Device, mountPoint string, mountOptions []string, fsOpts *model.FilesystemOpts) (*model.Mount, error) // Idempotent
 	BindMount(mountPoint string, newMountPoint string, rbind bool) error                                                            // Idempotent
+	BindUnmount(mountPoint string) error                                                                                            // Idempotent
 	UnmountDevice(device *model.Device, mountPoint string) (*model.Mount, error)                                                    // Idempotent
 	UnmountFileSystem(mountPoint string) (*model.Mount, error)                                                                      // Idempotent
 	GetMounts(serialNumber string) ([]*model.Mount, error)

--- a/chapi/chapidriver_darwin.go
+++ b/chapi/chapidriver_darwin.go
@@ -117,6 +117,11 @@ func (driver *MacDriver) BindMount(mountPoint string, newMountPoint string, rbin
 	return fmt.Errorf("not implemented")
 }
 
+// BindUnmount unmounts the given bind mount
+func (driver *MacDriver) BindUnmount(mountPoint string) error {
+	return fmt.Errorf("not implemented")
+}
+
 // ExpandDevice will expand the given device/filesystem on the host
 func (driver *MacDriver) ExpandDevice(targetPath string, volAccessType model.VolumeAccessType) error {
 	return fmt.Errorf("not implemented")

--- a/chapi/chapidriver_fake.go
+++ b/chapi/chapidriver_fake.go
@@ -96,6 +96,11 @@ func (driver *FakeDriver) BindMount(mountPoint string, newMountPoint string, rbi
 	return nil
 }
 
+// BindUnmount unmounts the given bind mount
+func (driver *FakeDriver) BindUnmount(mountPoint string) error {
+	return nil
+}
+
 // GetMounts reports all mounts on this host
 func (driver *FakeDriver) GetMounts(serialNumber string) ([]*model.Mount, error) {
 	device := &model.Device{

--- a/chapi/chapidriver_linux.go
+++ b/chapi/chapidriver_linux.go
@@ -9,11 +9,11 @@ import (
 	"os"
 	"strings"
 
-	uuid "github.com/satori/go.uuid"
 	"github.com/hpe-storage/common-host-libs/linux"
 	log "github.com/hpe-storage/common-host-libs/logger"
 	"github.com/hpe-storage/common-host-libs/model"
 	"github.com/hpe-storage/common-host-libs/util"
+	uuid "github.com/satori/go.uuid"
 	"sort"
 	"sync"
 )
@@ -274,6 +274,15 @@ func (driver *LinuxDriver) BindMount(mountPoint string, newMountPoint string, rb
 
 	// Bind Mount
 	return linux.RetryBindMount(mountPoint, newMountPoint, rbind)
+}
+
+// BindUnmount unmounts the given bind mount
+func (driver *LinuxDriver) BindUnmount(mountPoint string) error {
+	log.Tracef(">>>>> BindUnmount, mountPoint: %s", mountPoint)
+	defer log.Trace("<<<<< BindMount")
+
+	// Unmount given bind mount
+	return linux.RetryBindUnmount(mountPoint)
 }
 
 // UnmountDevice unmounts the given device from the given mount point


### PR DESCRIPTION
* Problem:
  * CSI driver is calling unmount call during nodeUnstage which does flush buffers as well
  * flush buffers can hang as there is base mount still present
* Implementation:
  * Add handler to just perform unmount of bind mount path, but no sync
* Testing:
* Review: gcostea, rkumar, sbyadarahalli
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>