### PR TITLE
Avoid checking /dev/disk/by-path entries for VST targets

### DIFF
--- a/linux/iscsi.go
+++ b/linux/iscsi.go
@@ -82,15 +82,15 @@ func RescanAndLoginToTarget(volume *model.Volume) (err error) {
 	ifaces, err := GetIfaces()
 	// treat iface path not found error as no ifaces bound
 	if err != nil && !os.IsNotExist(err) {
-		log.Errorf("Unable to retrieve Iscsi bound ifaces. Error: %s", err.Error())
-		return fmt.Errorf("Unable to retrieve Iscsi bound ifaces. Error: %s", err.Error())
+		log.Errorf("Unable to retrieve iSCSI bound ifaces. Error: %s", err.Error())
+		return fmt.Errorf("Unable to retrieve iSCSI bound ifaces. Error: %s", err.Error())
 	}
 
 	if strings.EqualFold(volume.TargetScope, GroupScope.String()) {
 		loggedInTargets, err := GetIscsiTargets()
 		if err != nil {
-			log.Errorf("Unable to retrieve Iscsi Targets Error: %s", err.Error())
-			return fmt.Errorf("Unable to retrieve Iscsi Targets Error: %s", err.Error())
+			log.Errorf("Unable to retrieve iSCSI Targets Error: %s", err.Error())
+			return fmt.Errorf("Unable to retrieve iSCSI Targets Error: %s", err.Error())
 		}
 		log.Trace("Logged in Targets :")
 		for _, target := range loggedInTargets {


### PR DESCRIPTION
Don't check for /dev/disk/by-path entries for VST targets and always
attempt login. Since the re-login attempt is more common with GST, we can
use those entries for lookup. This will avoid stale entry problem with
large number of targets repeatedly created/deleted.

Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>