### PR TITLE
Fix order of iscsi settings to happen before service restart

### DIFF
--- a/tunelinux/iscsi.go
+++ b/tunelinux/iscsi.go
@@ -404,13 +404,14 @@ func ConfigureIscsi() (err error) {
 		return err
 	}
 
-	// Start service
-	err = linux.ServiceCommand(iscsi, "start")
+	// Set best practice settings
+	err = SetIscsiRecommendations()
 	if err != nil {
 		return err
 	}
 
-	err = SetIscsiRecommendations()
+	// Start service
+	err = linux.ServiceCommand(iscsi, "start")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* Bug: https://github.com/hpe-storage/common-host-libs/issues/71
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>