### PR TITLE
chapi: synchronize exec calls to iscsiadm/multipathd, misc fixes

### DIFF
--- a/linux/device.go
+++ b/linux/device.go
@@ -1021,9 +1021,14 @@ func getDeviceHolders(dev *model.Device) (h string, err error) {
 	var re = regexp.MustCompile(holderPattern)
 	log.Tracef("Path =  %s", dev.Pathname)
 	directoryPath := fmt.Sprintf(sysBlockHolders, dev.Pathname)
+	// holders folder might not exist in some flavors
+	dirExists, _, err := util.FileExists(directoryPath)
+	if !dirExists {
+		return "", nil
+	}
 	// walk all files in directory
 	err = filepath.Walk(directoryPath, func(path string, info os.FileInfo, err error) error {
-		if !info.IsDir() {
+		if info != nil && !info.IsDir() {
 			//check for valid symlink
 			var link string
 			link, err = os.Readlink(filepath.Join(directoryPath, info.Name()))

--- a/linux/device.go
+++ b/linux/device.go
@@ -32,6 +32,7 @@ const (
 	dmSizeFormat        = "/sys/block/dm-%s/size"
 	devMapperPath       = "/dev/mapper/"
 	failedDevPath       = "failed to get device path"
+	notBlockDevice      = "not a block device"
 	deviceDoesNotExist  = "No such device or address"
 	noFileOrDirErr      = "No such file or directory"
 	offlinePathString   = "/sys/block/%s/device/state"
@@ -449,7 +450,7 @@ func createNimbleDevice(volume *model.Volume) (dev *model.Device, err error) {
 	cleanupStaleScsiPaths(volume)
 	// try to logout the iscsi target if we could not find a device by now for VST Volume
 	if volume.TargetScope != GroupScope.String() && volume.Iqn != "" {
-		iscsilogoutOfTarget(&model.IscsiTarget{Name: volume.Iqn})
+		iscsiLogoutOfTarget(&model.IscsiTarget{Name: volume.Iqn})
 	}
 	// Reached here signifies the device was not found, throw an error
 	return nil, fmt.Errorf("device not found with serial %s or target %s", volume.SerialNumber, volume.Iqn)

--- a/linux/iscsi.go
+++ b/linux/iscsi.go
@@ -511,7 +511,7 @@ func PerformDiscovery(discoveryIP string) (a model.IscsiTargets, err error) {
 	iscsiMutex.Lock()
 	defer iscsiMutex.Unlock()
 
-	args := []string{"-m", "discovery", "-t", "st", "-p", discoveryIP, "-o", "delete", "-o", "new"}
+	args := []string{"-m", "discovery", "-t", "st", "-p", discoveryIP, "-o", "new"}
 	out, _, err := util.ExecCommandOutput(iscsicmd, args)
 	if err != nil {
 		log.Error(err.Error())

--- a/linux/iscsi_test.go
+++ b/linux/iscsi_test.go
@@ -11,7 +11,7 @@ func TestDeleteEmptyTarget(t *testing.T) {
 		Address: "172.10.10.10",
 		Port:    "3260",
 	}
-	err := iscsideleteNode(target)
+	err := iscsiDeleteNode(target)
 	if err.Error() != "Empty target to delete Node" {
 		t.Error("empty target should not be allowed to be deleted")
 	}

--- a/linux/multipath.go
+++ b/linux/multipath.go
@@ -172,7 +172,6 @@ func checkIfDeviceCanBeDeleted(dev *model.Device) (err error) {
 		if err == nil {
 			return nil
 		}
-
 	}
 	return nil
 }

--- a/linux/multipath.go
+++ b/linux/multipath.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	log "github.com/hpe-storage/common-host-libs/logger"
@@ -13,14 +14,11 @@ import (
 	"github.com/hpe-storage/common-host-libs/util"
 )
 
-const (
-	maxTries = 3
-)
-
 var (
 	showPathsFormat  = []string{"show", "paths", "format", "%w %d %t %i %o %T %c %s %m"}
 	showMapsFormat   = []string{"show", "maps", "format", "%w %d %n %s"}
 	orphanPathRegexp = regexp.MustCompile(orphanPathsPattern)
+	multipathMutex   sync.Mutex
 )
 
 const (
@@ -29,22 +27,33 @@ const (
 	// MultipathBindings bindings file for multipathd
 	MultipathBindings  = "/etc/multipath/bindings"
 	orphanPathsPattern = ".*(?P<host>\\d+):(?P<channel>\\d+):(?P<target>\\d+):(?P<lun>\\d+).*Nimble.*orphan"
+	maxTries           = 3
 )
 
 // MultipathdShowMaps output
 func MultipathdShowMaps(serialNumber string) (a []string, err error) {
-	log.Tracef("MultipathdShowMaps for %s", serialNumber)
+	log.Tracef(">>>>> MultipathdShowMaps for %s", serialNumber)
+	defer log.Trace("<<<<< MultipathdShowMaps")
+
 	return multipathdShowCmd(showMapsFormat, serialNumber)
 }
 
 // MultipathdShowPaths output from Linux
 func MultipathdShowPaths(serialNumber string) (a []string, err error) {
-	log.Tracef("MultipathdShowPaths for %s", serialNumber)
+	log.Tracef(">>>>> MultipathdShowPaths for %s", serialNumber)
+	defer log.Trace("<<<<< MultipathdShowPaths")
+
 	return multipathdShowCmd(showPathsFormat, serialNumber)
 }
 
 // MultipathdReconfigure reconfigure multipathd settings
 func MultipathdReconfigure() (out string, err error) {
+	log.Trace(">>>>> MultipathdReconfigure")
+	defer log.Trace("<<<<<< MultipathdReconfigure")
+
+	multipathMutex.Lock()
+	defer multipathMutex.Unlock()
+
 	var args []string
 	args = []string{"reconfigure"}
 	out, _, err = util.ExecCommandOutput(multipathd, args)
@@ -60,8 +69,12 @@ func isMultipathTimeoutError(msg string) bool {
 }
 
 func multipathShowCmdOrphanPaths() (output []string, err error) {
-	log.Trace(">>>>> multipathShowCmdOrphanPaths called")
+	log.Trace(">>>>> multipathShowCmdOrphanPaths")
 	defer log.Trace("<<<<<< multipathShowCmdOrphanPaths")
+
+	multipathMutex.Lock()
+	defer multipathMutex.Unlock()
+
 	out, _, err := util.ExecCommandOutput(multipathd, showPathsFormat)
 	if err != nil {
 		log.Warnf("multipathdShowCmd: error %v with args %v", err, showPathsFormat)
@@ -79,6 +92,9 @@ func multipathShowCmdOrphanPaths() (output []string, err error) {
 }
 
 func multipathdShowCmd(args []string, serialNumber string) (output []string, err error) {
+	multipathMutex.Lock()
+	defer multipathMutex.Unlock()
+
 	out, _, err := util.ExecCommandOutput(multipathd, args)
 	if err != nil {
 		log.Warnf("multipathdShowCmd: error %v with args %v", err, args)
@@ -104,6 +120,7 @@ func multipathdShowCmd(args []string, serialNumber string) (output []string, err
 func tearDownMultipathDevice(dev *model.Device) (err error) {
 	log.Tracef(">>>>> tearDownMultipathDevice called for %s", dev.SerialNumber)
 	defer log.Trace("<<<<< tearDownMultipathDevice")
+
 	lines, err := MultipathdShowMaps(dev.SerialNumber)
 	if err != nil {
 		log.Trace(err)
@@ -162,7 +179,9 @@ func checkIfDeviceCanBeDeleted(dev *model.Device) (err error) {
 
 // retry for maxtries for device Cleanup
 func retryCleanupDeviceAndSlaves(dev *model.Device) error {
-	log.Trace("retryCleanupDeviceAndSlaves called")
+	log.Trace(">>>>> retryCleanupDeviceAndSlaves")
+	defer log.Trace("<<<<< retryCleanupDeviceAndSlaves")
+
 	//check if device is mounted or has holders
 	err := checkIfDeviceCanBeDeleted(dev)
 	if err != nil {
@@ -197,7 +216,8 @@ func retryCleanupDeviceAndSlaves(dev *model.Device) error {
 // cleanupDeviceAndSlaves : remove the multipath devices and its slaves and logout iscsi targets
 // nolint: gocyclo
 func cleanupDeviceAndSlaves(dev *model.Device) (err error) {
-	log.Tracef("cleanupDeviceAndSlaves called for %+v", dev)
+	log.Tracef(">>>>> cleanupDeviceAndSlaves called for %+v", dev)
+	defer log.Trace("<<<<< cleanupDeviceAndSlaves")
 
 	isFC := isFibreChannelDevice(dev.Slaves)
 
@@ -248,7 +268,9 @@ func cleanupDeviceAndSlaves(dev *model.Device) (err error) {
 }
 
 func deleteSdDevices(paths []*model.PathInfo) error {
-	log.Tracef("deleteSdDevices called")
+	log.Tracef(">>>>> deleteSdDevices")
+	defer log.Trace("<<<<< deleteSdDevices")
+
 	for _, path := range paths {
 		err := deleteSdDevice(path.Device)
 		if err != nil {
@@ -261,16 +283,18 @@ func deleteSdDevices(paths []*model.PathInfo) error {
 }
 
 func logoutAndDeleteIscsiTarget(dev *model.Device) error {
-	log.Tracef("logoutAndDeleteIscsiTarget called for device %s", dev.AltFullPathName)
+	log.Tracef(">>>>> logoutAndDeleteIscsiTarget for device %s", dev.AltFullPathName)
+	defer log.Tracef("<<<<< logoutAndDeleteIscsiTarget")
+
 	if dev.IscsiTarget != nil {
 		log.Tracef("initiating the iscsi target logout for %s of type %s", dev.IscsiTarget.Name, dev.IscsiTarget.Scope)
 		//logout of iscsi target
-		err := iscsilogoutOfTarget(dev.IscsiTarget)
+		err := iscsiLogoutOfTarget(dev.IscsiTarget)
 		if err != nil {
 			return fmt.Errorf("unable to logout iscsi target %s. Error: %s", dev.IscsiTarget, err.Error())
 		}
 		//delete iscsi node
-		err = iscsideleteNode(dev.IscsiTarget)
+		err = iscsiDeleteNode(dev.IscsiTarget)
 		if err != nil {
 			return fmt.Errorf("unable to delete iscsi target: %s. Error: %s", dev.IscsiTarget, err.Error())
 		}
@@ -280,7 +304,12 @@ func logoutAndDeleteIscsiTarget(dev *model.Device) error {
 
 // multipathDisableQueuing : disable queueing on the multipath device
 func multipathDisableQueuing(dev *model.Device) (err error) {
-	log.Tracef("multipathDisableQueuing")
+	log.Trace(">>>>> multipathDisableQueuing for", dev.MpathName)
+	defer log.Trace("<<<<< multipathDisableQueuing")
+
+	multipathMutex.Lock()
+	defer multipathMutex.Unlock()
+
 	args := []string{"message", dev.MpathName, "0", "fail_if_no_path"}
 	out, _, err := util.ExecCommandOutput(dmsetupcommand, args)
 	if err != nil {
@@ -294,7 +323,9 @@ func multipathDisableQueuing(dev *model.Device) (err error) {
 
 // multipathRemoveDmDevice : remove multipath device ps via dmsetup
 func multipathRemoveDmDevice(dev *model.Device) (err error) {
-	log.Tracef("multipathRemoveDmDevice called for %+v", dev)
+	log.Tracef(">>>>> multipathRemoveDmDevice called for %+v", dev)
+	defer log.Trace("<<<<< multipathRemoveDmDevice")
+
 	err = multipathRemoveMapDmSetup(dev)
 	if err != nil {
 		return fmt.Errorf("failed to remove multipath device %s. Error: %s ", dev.MpathName, err.Error())
@@ -305,7 +336,12 @@ func multipathRemoveDmDevice(dev *model.Device) (err error) {
 
 // multipathRemoveMapDmSetup : remove multipath maps via dmsetup
 func multipathRemoveMapDmSetup(dev *model.Device) (err error) {
-	log.Tracef("multipathRemoveMapDmSetup called for %+v", dev)
+	log.Tracef(">>>>> multipathRemoveMapDmSetup called for %+v", dev)
+	defer log.Trace("<<<<< multipathRemoveMapDmSetup")
+
+	multipathMutex.Lock()
+	defer multipathMutex.Unlock()
+
 	if dev.MpathName == "" {
 		err = setAltFullPathName(dev)
 		if err != nil {
@@ -326,6 +362,9 @@ func multipathRemoveMapDmSetup(dev *model.Device) (err error) {
 func cleanupErrorMultipathMaps() (err error) {
 	log.Traceln(">>> cleanupErrorMultipathMaps")
 	defer log.Traceln("<<< cleanupErrorMultipathMaps")
+
+	multipathMutex.Lock()
+	defer multipathMutex.Unlock()
 
 	// run dmsetup table ls and fetch error maps
 	args := []string{"table"}


### PR DESCRIPTION
* Problem:
  * simultaneous calls to iscsiadm/multipathd were causing them to fail with timeout etc.
  * getPartitions() was failing with error "not a block device" if called soon after device creation
  * logging cleanup
* Implementation:
  * synchronize calls to iscsiadm/multipathd
  * retry on failure to get partitions as multipath device setup takes few seconds
  * logging cleanup
* Testing: tested with 50 pods on Ubuntu 16.04 and CentOS 7.6. rate of multipathd/iscsid failures have drastically reduced.
* Review:gcostea, rkumar
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>