### PR TITLE
chapi: miscellaneous fixes for scale issues

### DIFF
--- a/chapi/chapidriver.go
+++ b/chapi/chapidriver.go
@@ -14,6 +14,7 @@ type Driver interface {
 	GetHostNetworks() ([]*model.Network, error)
 	GetHostNameAndDomain() ([]string, error)
 	CreateDevices(volumes []*model.Volume) ([]*model.Device, error)
+	GetDevice(volume *model.Volume) (*model.Device, error)
 	DeleteDevice(device *model.Device) error
 	OfflineDevice(device *model.Device) error
 	MountDevice(device *model.Device, mountPoint string, mountOptions []string, fsOpts *model.FilesystemOpts) (*model.Mount, error) // Idempotent

--- a/chapi/chapidriver_darwin.go
+++ b/chapi/chapidriver_darwin.go
@@ -92,6 +92,11 @@ func (driver *MacDriver) BindMountDevice(mountPoint string, newMountPoint string
 	return fmt.Errorf("not implemented")
 }
 
+// GetDevice will return device matching given volume serial
+func (driver *MacDriver) GetDevice(volume *model.Volume) (*model.Device, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 // CreateDevices will create devices on this host based on the volume details provided
 func (driver *MacDriver) CreateDevices(volumes []*model.Volume) ([]*model.Device, error) {
 	return nil, fmt.Errorf("not implemented")

--- a/chapi/chapidriver_fake.go
+++ b/chapi/chapidriver_fake.go
@@ -47,6 +47,15 @@ func (driver *FakeDriver) GetHostNameAndDomain() ([]string, error) {
 	}, nil
 }
 
+// GetDevice will return device matching given volume serial
+func (driver *FakeDriver) GetDevice(volume *model.Volume) (*model.Device, error) {
+	device := &model.Device{
+		SerialNumber:    volume.SerialNumber,
+		AltFullPathName: "/dev/mapper/fakeMpath",
+	}
+	return device, nil
+}
+
 // CreateDevices will create devices on this host based on the volume details provided
 func (driver *FakeDriver) CreateDevices(volumes []*model.Volume) ([]*model.Device, error) {
 	device := &model.Device{

--- a/chapi/chapidriver_linux.go
+++ b/chapi/chapidriver_linux.go
@@ -166,6 +166,10 @@ func (driver *LinuxDriver) CreateDevices(volumes []*model.Volume) ([]*model.Devi
 	return linux.CreateNimbleDevices(volumes)
 }
 
+func (driver *LinuxDriver) GetDevice(volume *model.Volume) (*model.Device, error) {
+	return linux.GetDeviceFromVolume(volume)
+}
+
 // CreateFilesystemOnDevice writes the given filesystem on the given device
 func (driver *LinuxDriver) CreateFilesystemOnDevice(device *model.Device, filesystemType string) error {
 	log.Tracef(">>>>> CreateFilesystemOnDevice, device: %+v, type: %s", device, filesystemType)

--- a/linux/device.go
+++ b/linux/device.go
@@ -39,7 +39,7 @@ const (
 	deletePathString    = "/sys/block/%s/device/delete"
 	sysBlockHolders     = "/sys/block/%s/holders/"
 	holderPattern       = "^.*dm-"
-	countdownTicker     = 30
+	countdownTicker     = 5
 	sectorstoMiBFactor  = 2 * 1024
 	procScsiPath        = "/proc/scsi/scsi"
 	procScsiPathLocal   = "/proc_local/scsi/scsi"
@@ -416,7 +416,7 @@ func createNimbleDevice(volume *model.Volume) (dev *model.Device, err error) {
 	// find multipath devices after the rescan and login
 	// Start a Countdown ticker
 	var devices []*model.Device
-	for i := 1; i <= countdownTicker; i++ {
+	for i := 0; i <= countdownTicker; i++ {
 		devices, err = GetNimbleDmDevices(true, GetLinuxSerialNumber(volume.SerialNumber), volume.LunID)
 		if err != nil {
 			return nil, err
@@ -443,8 +443,8 @@ func createNimbleDevice(volume *model.Volume) (dev *model.Device, err error) {
 		handleOrphanPaths(volume)
 		// check any error maps are present and cleanup
 		cleanupErrorMultipathMaps()
-		log.Debugf("sleeping for 1 second waiting for device %s to appear after rescan", volume.SerialNumber)
-		time.Sleep(time.Second * 1)
+		log.Debugf("sleeping for 5 seconds waiting for device %s to appear after rescan", volume.SerialNumber)
+		time.Sleep(time.Second * 5)
 	}
 	// cleanup paths which maybe part of lsscsi but not in multipath as we haven't found the device yet
 	cleanupStaleScsiPaths(volume)
@@ -864,9 +864,26 @@ func parseHctl(lunStr string) (h string, c string, t string, l string, err error
 	return h, c, t, l, nil
 }
 
+// GetDeviceFromVolume returns Linux device for given volume info
+func GetDeviceFromVolume(vol *model.Volume) (*model.Device, error) {
+	log.Tracef(">>>>> GetDeviceFromVolume for serial %s", vol.SerialNumber)
+	defer log.Trace("<<<<< GetDeviceFromVolume")
+
+	devices, err := GetNimbleDmDevices(false, vol.SerialNumber, vol.LunID)
+	if err != nil {
+		return nil, err
+	}
+	if len(devices) == 0 {
+		return nil, fmt.Errorf("unable to find device matching volume serial number %s", vol.SerialNumber)
+	}
+	return devices[0], nil
+}
+
 //CreateNimbleDevices : attached and creates nimble devices to host
 func CreateNimbleDevices(vols []*model.Volume) (devs []*model.Device, err error) {
-	log.Tracef("CreateNimbleDevices")
+	log.Tracef(">>>>> CreateNimbleDevices")
+	defer log.Trace("<<<<< CreateNimbleDevices")
+
 	var devices []*model.Device
 	for _, vol := range vols {
 		log.Tracef("create request with serialnumber :%s, accessprotocol %s discoveryip %s, iqn %s ", vol.SerialNumber, vol.AccessProtocol, vol.DiscoveryIP, vol.Iqn)
@@ -942,14 +959,17 @@ func offlineScsiDevice(path string) (err error) {
 // DeleteDevice : delete the multipath device
 func DeleteDevice(dev *model.Device) (err error) {
 	log.Tracef("DeleteDevice called with %s", dev.SerialNumber)
-	//validate nimble device
-	if serialNumberMatcher.MatchString(dev.SerialNumber) == false {
-		return fmt.Errorf("device %s is not a nimble device", dev.SerialNumber)
-	}
 	// perform cleanup of the multipath device
 	if dev.SerialNumber == "" {
 		return fmt.Errorf("no serialNumber of device %v present, failing delete", dev)
 	}
+
+	//check if device is mounted or has holders
+	err := checkIfDeviceCanBeDeleted(dev)
+	if err != nil {
+		return err
+	}
+
 	err = deletingDevices.addDevice(dev.SerialNumber)
 	if err != nil {
 		// indicates device deletion is already in progress, don't error out

--- a/linux/multipath.go
+++ b/linux/multipath.go
@@ -181,12 +181,6 @@ func retryCleanupDeviceAndSlaves(dev *model.Device) error {
 	log.Trace(">>>>> retryCleanupDeviceAndSlaves")
 	defer log.Trace("<<<<< retryCleanupDeviceAndSlaves")
 
-	//check if device is mounted or has holders
-	err := checkIfDeviceCanBeDeleted(dev)
-	if err != nil {
-		return err
-	}
-
 	// check if mpathName exists for the device, else populate it
 	if dev.MpathName == "" {
 		err = setAltFullPathName(dev)
@@ -329,6 +323,7 @@ func multipathRemoveDmDevice(dev *model.Device) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to remove multipath device %s. Error: %s ", dev.MpathName, err.Error())
 	}
+
 	log.Debugf("successfully removed the dm device %s", dev.MpathName)
 	return nil
 }

--- a/tunelinux/config/config.json
+++ b/tunelinux/config/config.json
@@ -109,7 +109,7 @@
         "severity": "warning",
         "description": "Minimum queue_depth of 64 is recommended for each iSCSI session/path. Can be set in /etc/iscsi/iscsid.conf",
         "parameter": "queue_depth",
-        "recommendation": "64"
+        "recommendation": "256"
     },
     {
         "category": "iscsi",


### PR DESCRIPTION
* Problem:
  * Need GetDevice() endpoint for csi driver to fetch current device from serial.
  * Remove code which checks for Nimble device pattern.
  * During device discovery don't agressively poll multipathd(i.e every second).
  * During deletion request, check if device is mounted as first thing to avoid unnecessary retries.
  * ISCSI queue_depth of 64 is very low for loaded system and TUR commands are taking ~16s to complete. This is the reason
  * for multipathd timeouts.
* Implementation:
  * Added GetDevice() endpoint for csi driver to fetch existing device by serial.
  * During device discovery changed polling interval to 5s, if we can't find multipath device after rescan. Thus
  * multipathd can process pending commands quickly
  * During deletion request, if device is mounted, error out immediately rathern than entering retry loop.
  * Increase iSCSI adapter queue_depth to 512 to avoid scalability issues. This needs to be tuned as how tests progress.
* Testing: scale testign with multiple failover/failback of pods.
* Review:
* Bug: https://nimblejira.nimblestorage.com/browse/NLT-
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>