### PR TITLE
chapi : support for cidr networks

### DIFF
--- a/chapi/chapiclient.go
+++ b/chapi/chapiclient.go
@@ -215,7 +215,7 @@ func (chapiClient *Client) GetChapInfo() (chapInfo *model.ChapInfo, err error) {
 }
 
 // GetNetworks return list of host network interface details
-func (chapiClient *Client) GetNetworks() (networks []*model.Network, err error) {
+func (chapiClient *Client) GetNetworks() (networks []*model.NetworkInterface, err error) {
 	log.Trace("GetNetworks called")
 
 	// fetch host ID

--- a/chapi/chapidriver.go
+++ b/chapi/chapidriver.go
@@ -11,7 +11,7 @@ type Driver interface {
 	GetHosts() (*model.Hosts, error)
 	GetHostInfo() (*model.Host, error)
 	GetHostInitiators() ([]*model.Initiator, error)
-	GetHostNetworks() ([]*model.Network, error)
+	GetHostNetworks() ([]*model.NetworkInterface, error)
 	GetHostNameAndDomain() ([]string, error)
 	CreateDevices(volumes []*model.Volume) ([]*model.Device, error)
 	DeleteDevice(device *model.Device) error

--- a/chapi/chapidriver_fake.go
+++ b/chapi/chapidriver_fake.go
@@ -35,7 +35,7 @@ func (driver *FakeDriver) GetHostInitiators() ([]*model.Initiator, error) {
 }
 
 // GetHostNetworks reports the networks on this host
-func (driver *FakeDriver) GetHostNetworks() ([]*model.Network, error) {
+func (driver *FakeDriver) GetHostNetworks() ([]*model.NetworkInterface, error) {
 	return nil, nil
 }
 

--- a/chapi/chapidriver_linux.go
+++ b/chapi/chapidriver_linux.go
@@ -87,7 +87,7 @@ func generateUniqueNodeId() (string, error) {
 
 func getMacAddresses() ([]string, error) {
 	// get mac address
-	nics, err := linux.GetNetworkInterfaces()
+	nics, err := linux.GetNetworkInterfaces(false)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +129,7 @@ func (driver *LinuxDriver) GetHostInfo() (*model.Host, error) {
 		return nil, err
 	}
 
-	nics, err := linux.GetNetworkInterfaces()
+	nics, err := linux.GetNetworkInterfaces(false)
 	if err != nil {
 		log.Errorln("GetNetworkInterfaces returned error:", err)
 		if len(nics) == 0 {
@@ -153,7 +153,8 @@ func (driver *LinuxDriver) GetHostInitiators() ([]*model.Initiator, error) {
 
 // GetHostNetworks reports the networks on this host
 func (driver *LinuxDriver) GetHostNetworks() ([]*model.Network, error) {
-	return linux.GetNetworkInterfaces()
+	// need cidr network addresses
+	return linux.GetNetworkInterfaces(true)
 }
 
 // GetHostNameAndDomain reports the host name and domain

--- a/chapi/chapidriver_linux.go
+++ b/chapi/chapidriver_linux.go
@@ -139,9 +139,9 @@ func (driver *LinuxDriver) GetHostInfo() (*model.Host, error) {
 	}
 
 	host := &model.Host{
-		Name:     hostAndDomain[0],
-		Domain:   hostAndDomain[1],
-		Networks: nics,
+		Name:              hostAndDomain[0],
+		Domain:            hostAndDomain[1],
+		NetworkInterfaces: nics,
 	}
 	return host, nil
 }

--- a/chapi/chapidriver_linux.go
+++ b/chapi/chapidriver_linux.go
@@ -87,7 +87,7 @@ func generateUniqueNodeId() (string, error) {
 
 func getMacAddresses() ([]string, error) {
 	// get mac address
-	nics, err := linux.GetNetworkInterfaces(false)
+	nics, err := linux.GetNetworkInterfaces()
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +129,7 @@ func (driver *LinuxDriver) GetHostInfo() (*model.Host, error) {
 		return nil, err
 	}
 
-	nics, err := linux.GetNetworkInterfaces(false)
+	nics, err := linux.GetNetworkInterfaces()
 	if err != nil {
 		log.Errorln("GetNetworkInterfaces returned error:", err)
 		if len(nics) == 0 {
@@ -153,8 +153,7 @@ func (driver *LinuxDriver) GetHostInitiators() ([]*model.Initiator, error) {
 
 // GetHostNetworks reports the networks on this host
 func (driver *LinuxDriver) GetHostNetworks() ([]*model.Network, error) {
-	// need cidr network addresses
-	return linux.GetNetworkInterfaces(true)
+	return linux.GetNetworkInterfaces()
 }
 
 // GetHostNameAndDomain reports the host name and domain

--- a/chapi/chapidriver_linux.go
+++ b/chapi/chapidriver_linux.go
@@ -152,7 +152,7 @@ func (driver *LinuxDriver) GetHostInitiators() ([]*model.Initiator, error) {
 }
 
 // GetHostNetworks reports the networks on this host
-func (driver *LinuxDriver) GetHostNetworks() ([]*model.Network, error) {
+func (driver *LinuxDriver) GetHostNetworks() ([]*model.NetworkInterface, error) {
 	return linux.GetNetworkInterfaces()
 }
 

--- a/chapi/handler_linux.go
+++ b/chapi/handler_linux.go
@@ -565,7 +565,7 @@ func getHostInitiators(w http.ResponseWriter, r *http.Request) {
 //@Router /hosts/{id}/network [get]
 func getHostNetworks(w http.ResponseWriter, r *http.Request) {
 	var chapiResp Response
-	var nics []*model.Network
+	var nics []*model.NetworkInterface
 	vars := mux.Vars(r)
 	hostid := vars["id"]
 

--- a/chapi/handler_linux.go
+++ b/chapi/handler_linux.go
@@ -575,7 +575,7 @@ func getHostNetworks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	nics, err = linux.GetNetworkInterfaces()
+	nics, err = linux.GetNetworkInterfaces(false)
 	if err != nil {
 		handleError(w, chapiResp, err, http.StatusInternalServerError)
 		return

--- a/chapi/handler_linux.go
+++ b/chapi/handler_linux.go
@@ -575,7 +575,7 @@ func getHostNetworks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	nics, err = linux.GetNetworkInterfaces(false)
+	nics, err = linux.GetNetworkInterfaces()
 	if err != nil {
 		handleError(w, chapiResp, err, http.StatusInternalServerError)
 		return

--- a/dockerplugin/handler/handler.go
+++ b/dockerplugin/handler/handler.go
@@ -136,14 +136,14 @@ type VersionResponse struct {
 
 // Host is a duplicate of model.Host which references a Network defined in this package
 type Host struct {
-	UUID           string                    `json:"id,omitempty"`
-	Name           string                    `json:"name,omitempty"`
-	Domain         string                    `json:"domain,omitempty"`
-	NodeID         string                    `json:"node_id,omitempty"`
-	AccessProtocol string                    `json:"access_protocol,omitempty"`
-	Networks       []*model.NetworkInterface `json:"networks,omitempty"`
-	Initiators     []*model.Initiator        `json:"initiators,omitempty"`
-	Version        string                    `json:"version,omitempty"`
+	UUID              string                    `json:"id,omitempty"`
+	Name              string                    `json:"name,omitempty"`
+	Domain            string                    `json:"domain,omitempty"`
+	NodeID            string                    `json:"node_id,omitempty"`
+	AccessProtocol    string                    `json:"access_protocol,omitempty"`
+	NetworkInterfaces []*model.NetworkInterface `json:"networks,omitempty"`
+	Initiators        []*model.Initiator        `json:"initiators,omitempty"`
+	Version           string                    `json:"version,omitempty"`
 }
 
 // populate hostcontext into request and fetch user info if running in cloud vm

--- a/dockerplugin/handler/handler.go
+++ b/dockerplugin/handler/handler.go
@@ -136,14 +136,14 @@ type VersionResponse struct {
 
 // Host is a duplicate of model.Host which references a Network defined in this package
 type Host struct {
-	UUID           string             `json:"id,omitempty"`
-	Name           string             `json:"name,omitempty"`
-	Domain         string             `json:"domain,omitempty"`
-	NodeID         string             `json:"node_id,omitempty"`
-	AccessProtocol string             `json:"access_protocol,omitempty"`
-	Networks       []*model.Network   `json:"networks,omitempty"`
-	Initiators     []*model.Initiator `json:"initiators,omitempty"`
-	Version        string             `json:"version,omitempty"`
+	UUID           string                    `json:"id,omitempty"`
+	Name           string                    `json:"name,omitempty"`
+	Domain         string                    `json:"domain,omitempty"`
+	NodeID         string                    `json:"node_id,omitempty"`
+	AccessProtocol string                    `json:"access_protocol,omitempty"`
+	Networks       []*model.NetworkInterface `json:"networks,omitempty"`
+	Initiators     []*model.Initiator        `json:"initiators,omitempty"`
+	Version        string                    `json:"version,omitempty"`
 }
 
 // populate hostcontext into request and fetch user info if running in cloud vm

--- a/dockerplugin/handler/host_handler.go
+++ b/dockerplugin/handler/host_handler.go
@@ -143,8 +143,8 @@ func buildHostContext(body io.ReadCloser) (*Host, error) {
 	}
 	// populate host context
 	hostContext = &Host{
-		Initiators: initiators,
-		Networks:   networks,
+		Initiators:        initiators,
+		NetworkInterfaces: networks,
 	}
 	hostContext.Domain = host.Domain
 	hostContext.Name = host.Name

--- a/dockerplugin/handler/mount.go
+++ b/dockerplugin/handler/mount.go
@@ -238,17 +238,17 @@ func filterHostNetworks(pluginReq *PluginRequest) error {
 	index := 0
 	for _, initiator := range initiators {
 		// ignore unwanted networks based on user input
-		for _, network := range pluginReq.Host.Networks {
+		for _, network := range pluginReq.Host.NetworkInterfaces {
 			// check if initiator ip addresses or interfaces are provided to match with current node
 			if (isIPAddress(initiator) && network.AddressV4 == initiator) || network.Name == initiator {
-				pluginReq.Host.Networks[index] = network
+				pluginReq.Host.NetworkInterfaces[index] = network
 				log.Debugf("matched filtered network %s, ip %s", network.Name, network.AddressV4)
 				index++
 			}
 		}
 	}
 	// trim unwanted network interfaces
-	pluginReq.Host.Networks = pluginReq.Host.Networks[:index]
+	pluginReq.Host.NetworkInterfaces = pluginReq.Host.NetworkInterfaces[:index]
 
 	return nil
 }
@@ -603,7 +603,7 @@ func isCurrentHostAttachedIscsi(volume *model.Volume, pluginReq *PluginRequest) 
 			}
 		}
 		if iscsiSession.InitiatorIP != "" {
-			for _, network := range pluginReq.Host.Networks {
+			for _, network := range pluginReq.Host.NetworkInterfaces {
 				if strings.TrimSpace(iscsiSession.InitiatorIP) == strings.TrimSpace(network.AddressV4) {
 					log.Debugf("host iscsi initiator %s matched volume iscsi connection", network.AddressV4)
 					return true

--- a/linux/device.go
+++ b/linux/device.go
@@ -870,7 +870,7 @@ func CreateNimbleDevices(vols []*model.Volume) (devs []*model.Device, err error)
 	var devices []*model.Device
 	for _, vol := range vols {
 		log.Tracef("create request with serialnumber :%s, accessprotocol %s discoveryip %s, iqn %s ", vol.SerialNumber, vol.AccessProtocol, vol.DiscoveryIP, vol.Iqn)
-		if vol.AccessProtocol == iscsi && (vol.DiscoveryIP == "" || vol.Iqn == "") {
+		if vol.AccessProtocol == iscsi && (vol.DiscoveryIP == "" || vol.Iqn == "") && len(vol.DiscoveryIPs) == 0 {
 			return nil, fmt.Errorf("cannot discover without IP. Please sanity check host OS and array IP configuration, network, netmask and gateway")
 		}
 		device, err := createNimbleDevice(vol)

--- a/linux/iscsi.go
+++ b/linux/iscsi.go
@@ -321,14 +321,14 @@ func addTarget(target *model.IscsiTarget, ifaces []*model.Iface) (err error) {
 	if len(ifaces) > 0 {
 		for _, iface := range ifaces {
 			// verify if the target is reachable from this interface
-			reachable, err := isReachable(iface.Network.AddressV4, target.Address)
+			reachable, err := isReachable(iface.NetworkInterface.AddressV4, target.Address)
 			if err != nil {
-				log.Warnf("failed to run ping test from %s --> (%s)", iface.Network.AddressV4, target.Address)
+				log.Warnf("failed to run ping test from %s --> (%s)", iface.NetworkInterface.AddressV4, target.Address)
 				// if we cannot issue ping for some reason, proceed with iscsi login
 				reachable = true
 			}
 			if !reachable {
-				log.Errorf("ping test failed from %s --> (%s), skipping iscsi login on this portal to %s", iface.Network.AddressV4, target.Address, target.Name)
+				log.Errorf("ping test failed from %s --> (%s), skipping iscsi login on this portal to %s", iface.NetworkInterface.AddressV4, target.Address, target.Name)
 				continue
 			}
 			// login using each iface bound
@@ -405,7 +405,7 @@ func GetIfaces() (ifaces []*model.Iface, err error) {
 			for _, network := range networks {
 				if network.Name == strings.TrimSpace(lines[0]) {
 					log.Trace("found iface ", file.Name(), " bound to network ", network)
-					iface.Network = network
+					iface.NetworkInterface = network
 					log.Trace("iface added ", iface.Name)
 					ifaces = append(ifaces, iface)
 					break
@@ -803,7 +803,7 @@ func addIscsiPortBinding(networks []*model.NetworkInterface) error {
 		if iface != nil {
 			found = true
 			// check if iface had binding with network interface
-			if iface.Network.Name == network.Name {
+			if iface.NetworkInterface.Name == network.Name {
 				bound = true
 			}
 		}
@@ -826,7 +826,7 @@ func addIscsiPortBinding(networks []*model.NetworkInterface) error {
 // returns iface matching the network address specified or nil otherwise
 func getMatchingIface(ifaces []*model.Iface, network *model.NetworkInterface) (iface *model.Iface) {
 	for _, iface := range ifaces {
-		if network.AddressV4 == iface.Network.AddressV4 {
+		if network.AddressV4 == iface.NetworkInterface.AddressV4 {
 			return iface
 		}
 	}

--- a/linux/iscsi.go
+++ b/linux/iscsi.go
@@ -391,7 +391,7 @@ func GetIfaces() (ifaces []*model.Iface, err error) {
 	}
 
 	// get network interfaces
-	networks, err := GetNetworkInterfaces(false)
+	networks, err := GetNetworkInterfaces()
 	if err != nil {
 		return nil, fmt.Errorf("Unable to get the network interfaces on host: Error: %s", err.Error())
 	}

--- a/linux/network.go
+++ b/linux/network.go
@@ -110,7 +110,7 @@ func GetIPV4NetworkAddress(ipv4Address, netMask string) (networkAddress string, 
 }
 
 //GetNetworkInterfaces : get the array of network interfaces
-func GetNetworkInterfaces() ([]*model.Network, error) {
+func GetNetworkInterfaces() ([]*model.NetworkInterface, error) {
 	log.Trace(">>>>> GetNetworkInterfaces called")
 	defer log.Trace("<<<<< GetNetworkInterfaces")
 
@@ -122,14 +122,14 @@ func GetNetworkInterfaces() ([]*model.Network, error) {
 }
 
 // retrieve network interfaces
-func getNetworkInterfaces() ([]*model.Network, error) {
+func getNetworkInterfaces() ([]*model.NetworkInterface, error) {
 	log.Trace(">>>>> getNetworkInterfaces called")
 	defer log.Trace("<<<<< getNetworkInterfaces")
 	ifaces, err := net.Interfaces()
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve network interfaces %s", err.Error())
 	}
-	var nics []*model.Network
+	var nics []*model.NetworkInterface
 	for _, i := range ifaces {
 		addrs, err := i.Addrs()
 		if err != nil {
@@ -144,7 +144,7 @@ func getNetworkInterfaces() ([]*model.Network, error) {
 					// continue with other addresses
 					continue
 				}
-				nic := &model.Network{
+				nic := &model.NetworkInterface{
 					Name:        i.Name,
 					AddressV4:   networkIp.IP.To4().String(),
 					MaskV4:      fmt.Sprintf("%d.%d.%d.%d", mask[0], mask[1], mask[2], mask[3]),
@@ -186,12 +186,12 @@ func getMaskString(intMask int) string {
 }
 
 //TODO: remove this
-func getInterfacesIPAddr() ([]*model.Network, error) {
+func getInterfacesIPAddr() ([]*model.NetworkInterface, error) {
 	log.Trace(">>>>> getInterfacesIpAddr")
 	defer log.Trace("<<<<< getInterfacesIPAddr")
 
-	var nics []*model.Network
-	var nic *model.Network
+	var nics []*model.NetworkInterface
+	var nic *model.NetworkInterface
 	args := []string{"addr"}
 	out, _, err := util.ExecCommandOutput(ipcommand, args)
 	if err != nil {
@@ -213,15 +213,15 @@ func getInterfacesIPAddr() ([]*model.Network, error) {
 				return nics, er
 			}
 			if matchedMap["UP"] == up {
-				nic = &model.Network{Name: matchedMap["Name"], Mtu: mtu, Up: true}
+				nic = &model.NetworkInterface{Name: matchedMap["Name"], Mtu: mtu, Up: true}
 			} else if matchedMap["UP"] == unknown {
 				// ip addr and ip link shows state as UNKNOWN with old kernel versions(/sys/class/net/docker0/operstate)
 				// https://access.redhat.com/solutions/1443363
 				// obtain using ethtool
 				status := getInterfaceStatus(matchedMap["Name"])
-				nic = &model.Network{Name: matchedMap["Name"], Mtu: mtu, Up: status}
+				nic = &model.NetworkInterface{Name: matchedMap["Name"], Mtu: mtu, Up: status}
 			} else {
-				nic = &model.Network{Name: matchedMap["Name"], Mtu: mtu, Up: false}
+				nic = &model.NetworkInterface{Name: matchedMap["Name"], Mtu: mtu, Up: false}
 			}
 		} else {
 			if nic != nil {
@@ -254,7 +254,7 @@ func getInterfaceStatus(name string) bool {
 	return false
 }
 
-func matchIPPattern(line string, nic *model.Network) (*model.Network, error) {
+func matchIPPattern(line string, nic *model.NetworkInterface) (*model.NetworkInterface, error) {
 	log.Tracef(">>>> matchIPPattern called with %s", line)
 	defer log.Trace("<<<<< matchIPPattern")
 

--- a/model/types.go
+++ b/model/types.go
@@ -86,13 +86,13 @@ func (e VolumeAccessType) String() string {
 
 // Host : provide host information
 type Host struct {
-	UUID           string       `json:"id,omitempty"`
-	Name           string       `json:"name,omitempty"`
-	Domain         string       `json:"domain,omitempty"`
-	NodeID         string       `json:"node_id,omitempty"`
-	AccessProtocol string       `json:"access_protocol,omitempty"`
-	Networks       []*Network   `json:"networks,omitempty"`
-	Initiators     []*Initiator `json:"initiators,omitempty"`
+	UUID           string              `json:"id,omitempty"`
+	Name           string              `json:"name,omitempty"`
+	Domain         string              `json:"domain,omitempty"`
+	NodeID         string              `json:"node_id,omitempty"`
+	AccessProtocol string              `json:"access_protocol,omitempty"`
+	Networks       []*NetworkInterface `json:"networks,omitempty"`
+	Initiators     []*Initiator        `json:"initiators,omitempty"`
 }
 
 //Mount struct ID data type is string
@@ -103,8 +103,8 @@ type Mount struct {
 	Device     *Device  `json:"device,omitempty"`
 }
 
-//Network : network interface info for host
-type Network struct {
+//NetworkInterface : network interface info for host
+type NetworkInterface struct {
 	Name        string `json:"name,omitempty"`
 	AddressV4   string `json:"address_v4,omitempty"`
 	MaskV4      string `json:"mask_v4,omitempty"`
@@ -185,7 +185,7 @@ type Volume struct {
 	MountPoint     string                 `json:"Mountpoint,omitempty"`
 	Status         map[string]interface{} `json:"status,omitempty"` // interface so that we can map any number of arguments
 	Chap           *ChapInfo              `json:"chap_info,omitempty"`
-	Networks       []*Network             `json:"networks,omitempty"`
+	Networks       []*NetworkInterface    `json:"networks,omitempty"`
 	ConnectionMode string                 `json:"connection_mode,omitempty"`
 	LunID          string                 `json:"lun_id,omitempty"`
 	TargetScope    string                 `json:"target_scope,omitempty"` //GST="group", VST="volume" or empty(older array fiji etc), and no-op for FC
@@ -282,7 +282,7 @@ type FcHostPort struct {
 // Iface represents iface configuring with port binding
 type Iface struct {
 	Name    string
-	Network *Network
+	Network *NetworkInterface
 }
 
 // IscsiTargets : array of pointers to IscsiTarget

--- a/model/types.go
+++ b/model/types.go
@@ -105,14 +105,14 @@ type Mount struct {
 
 //Network : network interface info for host
 type Network struct {
-	Name         string `json:"name,omitempty"`
-	AddressV4    string `json:"address_v4,omitempty"`
-	MaskV4       string `json:"mask_v4,omitempty"`
-	BroadcastV4  string `json:",omitempty"`
-	Mac          string `json:",omitempty"`
-	Mtu          int64  `json:",omitempty"`
-	Up           bool
-	CIDRNetworks []*string `json:",omitempty"`
+	Name        string `json:"name,omitempty"`
+	AddressV4   string `json:"address_v4,omitempty"`
+	MaskV4      string `json:"mask_v4,omitempty"`
+	BroadcastV4 string `json:",omitempty"`
+	Mac         string `json:",omitempty"`
+	Mtu         int64  `json:",omitempty"`
+	Up          bool
+	CidrNetwork string
 }
 
 //Initiator : Host initiator

--- a/model/types.go
+++ b/model/types.go
@@ -105,13 +105,14 @@ type Mount struct {
 
 //Network : network interface info for host
 type Network struct {
-	Name        string `json:"name,omitempty"`
-	AddressV4   string `json:"address_v4,omitempty"`
-	MaskV4      string `json:"mask_v4,omitempty"`
-	BroadcastV4 string `json:",omitempty"`
-	Mac         string `json:",omitempty"`
-	Mtu         int64  `json:",omitempty"`
-	Up          bool
+	Name         string `json:"name,omitempty"`
+	AddressV4    string `json:"address_v4,omitempty"`
+	MaskV4       string `json:"mask_v4,omitempty"`
+	BroadcastV4  string `json:",omitempty"`
+	Mac          string `json:",omitempty"`
+	Mtu          int64  `json:",omitempty"`
+	Up           bool
+	CIDRNetworks []*string `json:",omitempty"`
 }
 
 //Initiator : Host initiator
@@ -180,6 +181,7 @@ type Volume struct {
 	AccessProtocol string                 `json:"access_protocol,omitempty"`
 	Iqn            string                 `json:"iqn,omitempty"`
 	DiscoveryIP    string                 `json:"discovery_ip,omitempty"` // this field needs to be moved out ?
+	DiscoveryIPs   []string               `json:"discovery_ips,omitempty"`
 	MountPoint     string                 `json:"Mountpoint,omitempty"`
 	Status         map[string]interface{} `json:"status,omitempty"` // interface so that we can map any number of arguments
 	Chap           *ChapInfo              `json:"chap_info,omitempty"`

--- a/model/types.go
+++ b/model/types.go
@@ -86,13 +86,13 @@ func (e VolumeAccessType) String() string {
 
 // Host : provide host information
 type Host struct {
-	UUID           string              `json:"id,omitempty"`
-	Name           string              `json:"name,omitempty"`
-	Domain         string              `json:"domain,omitempty"`
-	NodeID         string              `json:"node_id,omitempty"`
-	AccessProtocol string              `json:"access_protocol,omitempty"`
-	Networks       []*NetworkInterface `json:"networks,omitempty"`
-	Initiators     []*Initiator        `json:"initiators,omitempty"`
+	UUID              string              `json:"id,omitempty"`
+	Name              string              `json:"name,omitempty"`
+	Domain            string              `json:"domain,omitempty"`
+	NodeID            string              `json:"node_id,omitempty"`
+	AccessProtocol    string              `json:"access_protocol,omitempty"`
+	NetworkInterfaces []*NetworkInterface `json:"networks,omitempty"`
+	Initiators        []*Initiator        `json:"initiators,omitempty"`
 }
 
 //Mount struct ID data type is string
@@ -281,8 +281,8 @@ type FcHostPort struct {
 
 // Iface represents iface configuring with port binding
 type Iface struct {
-	Name    string
-	Network *NetworkInterface
+	Name             string
+	NetworkInterface *NetworkInterface
 }
 
 // IscsiTargets : array of pointers to IscsiTarget

--- a/tunelinux/iscsi.go
+++ b/tunelinux/iscsi.go
@@ -138,7 +138,7 @@ func getIfaceRecommendation() (recommendation *Recommendation, err error) {
 
 	for _, iface := range ifaces {
 		// identify mismatch between network subnets of all ifaces
-		networkAddress, err := linux.GetIPV4NetworkAddress(iface.Network.AddressV4, iface.Network.MaskV4)
+		networkAddress, err := linux.GetIPV4NetworkAddress(iface.NetworkInterface.AddressV4, iface.NetworkInterface.MaskV4)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
* Problem:
- support for cidr networks
- also support for multiple ip addresses on same interface https://github.com/hpe-storage/common-host-libs/issues/77
- support multiple discovery ips
* Implementation:
to minimize the impact to existing chapi,flexvolume introduce new fields for CSI specific
* Testing:
tested with multiple interfaces and interface with multiple ips
* Bug: https://nimblejira.nimblestorage.com/browse/CON-568