### PR TITLE
Validating Approach for Filesystem Create Options

### DIFF
--- a/chapi/chapidriver_linux.go
+++ b/chapi/chapidriver_linux.go
@@ -242,9 +242,16 @@ func (driver *LinuxDriver) MountDevice(device *model.Device, mountPoint string, 
 
 	// Setup FS if requested
 	if fsOpts != nil {
-		// Create filesystem if not present
-		if err := linux.SetupFilesystem(device, fsOpts.Type); err != nil {
-			return nil, fmt.Errorf("Error creating filesystem %s on device with serialNumber %s, %v", fsOpts.Type, device.SerialNumber, err.Error())
+		if fsOpts.GetCreateOpts() != nil {
+			// Create filesystem if not present
+			if err := linux.SetupFilesystemWithOptions(device, fsOpts.Type, fsOpts.GetCreateOpts()); err != nil {
+				return nil, fmt.Errorf("Error creating filesystem %s on device with serialNumber %s, %v", fsOpts.Type, device.SerialNumber, err.Error())
+			}
+		} else {
+			// Create filesystem if not present
+			if err := linux.SetupFilesystem(device, fsOpts.Type); err != nil {
+				return nil, fmt.Errorf("Error creating filesystem %s on device with serialNumber %s, %v", fsOpts.Type, device.SerialNumber, err.Error())
+			}
 		}
 		log.Tracef("Filesystem %+v setup successful,", fsOpts)
 	}

--- a/model/types.go
+++ b/model/types.go
@@ -2,6 +2,8 @@ package model
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 )
 
 const (
@@ -298,9 +300,23 @@ type Hosts []*Host
 
 // FilesystemOpts to store fsType, fsMode, fsOwner options
 type FilesystemOpts struct {
-	Type  string
-	Mode  string
-	Owner string
+	Type       string
+	Mode       string
+	Owner      string
+	CreateOpts string
+}
+
+// GetCreateOpts returns a clean array that can be passed to the command line
+func (f FilesystemOpts) GetCreateOpts() []string {
+	cleanCharRe := regexp.MustCompile(`[^a-zA-Z0-9=, \-]`)
+	singleSpacesRe := regexp.MustCompile(`\s+`)
+
+	clean := cleanCharRe.ReplaceAllString(strings.Trim(f.CreateOpts, " "), "")
+	cleanSlice := strings.Split(singleSpacesRe.ReplaceAllString(clean, " "), " ")
+	if len(cleanSlice) == 1 && cleanSlice[0] == "" {
+		return nil
+	}
+	return cleanSlice
 }
 
 // PathInfo :

--- a/model/types_test.go
+++ b/model/types_test.go
@@ -1,0 +1,54 @@
+/*
+(c) Copyright 2019 Hewlett Packard Enterprise Development LP
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	"testing"
+)
+
+var argTests = []struct {
+	name    string
+	input   string
+	results []string
+}{
+	{"nothing", "", nil},
+	{"normal -a -b -c", "-a -b  -c", []string{"-a", "-b", "-c"}},
+	{"some extra spaces", "-a -b  -c", []string{"-a", "-b", "-c"}},
+	{"some extra spaces early", " -a -b  -c", []string{"-a", "-b", "-c"}},
+	{"some extra spaces late", " -a -b  -c ", []string{"-a", "-b", "-c"}},
+	{"danger ;", ";init 0", []string{"init", "0"}},
+	{"danger &", "&init 0", []string{"init", "0"}},
+	{"danger &&", "&&init 0", []string{"init", "0"}},
+	{"danger ||", "||init 0", []string{"init", "0"}},
+	{"xfs example", "-m crc=1 -K -i maxpct=0 -d agsize=9999999999999", []string{"-m", "crc=1", "-K", "-i", "maxpct=0", "-d", "agsize=9999999999999"}},
+	{"ext example", "-E stride=16,stripe-width=64 -c", []string{"-E", "stride=16,stripe-width=64", "-c"}},
+}
+
+func TestGetFilesystemOpts(t *testing.T) {
+	for _, tc := range argTests {
+		t.Run(tc.name, func(t *testing.T) {
+			fsopts := FilesystemOpts{"", "", "", tc.input}
+			safe := fsopts.GetCreateOpts()
+			if tc.results == nil && safe == nil {
+				return
+			}
+			for i := range tc.results {
+				if safe[i] != tc.results[i] {
+					t.Error("For", tc.name, "expected", tc.results[i], "got", safe[i], "expected array", tc.results, "returned array", safe)
+				}
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
**Goal**
- Allow the user to pass command line options for use during filesystem creation.
- Options shall be opaque to this process
  - Options not validated
  - Options are limited to ```[a-zA-Z0-9=, \-]``` 

**Considerations:**
- There are a bunch of functions in the call stack to create a filesystem that are publicly scoped
  - I maintained the public function signatures in case another application is using one of these
  - The new functions can handle a nil for the options slice ([]string), so either should be safe
- The CHAPI interface leverages model.FilesystemOpts, which makes easy to sneak in the create options

**What I did:**
- Added a string to FilesystemOpts to capture create command line parameters (model)
- Added a function GetCreateOpts() to safely break the string into an array of strings needed for command line execution (model)
- Updated chapidriver_linux to use the new functionality if GetCreateOpts() != nil (chaps)
- Created a new set of functions to create a filesystem using the optional slice (linux)

**To do:**
- Actually test this on a linux box