### PR TITLE
chapi: fix misc issues and support other vendors

### DIFF
--- a/chapi/chapiclient.go
+++ b/chapi/chapiclient.go
@@ -430,7 +430,7 @@ func (chapiClient *Client) GetDeviceFromVolume(volume *model.Volume) (device *mo
 	if err != nil {
 		return nil, err
 	}
-	serialNumber := GetSerialNumber(volume.SerialNumber)
+	serialNumber := volume.SerialNumber
 	devicesURI := fmt.Sprintf(DeviceURIfmt, fmt.Sprintf(HostURIfmt, chapiClient.hostID), serialNumber)
 
 	var errResp *ErrorResponse
@@ -455,7 +455,7 @@ func (chapiClient *Client) GetDeviceFromVolume(volume *model.Volume) (device *mo
 	return device, nil
 }
 
-// GetMounts will return all mounted nimble volumes on the host
+// GetMounts will return all mountpoints of a volume with given serial
 func (chapiClient *Client) GetMounts(respMount *[]*model.Mount, serialNumber string) (err error) {
 	log.Trace("GetMounts called")
 	// fetch host ID
@@ -489,14 +489,14 @@ func (chapiClient *Client) UnmountDevice(volume *model.Volume) error {
 	defer log.Trace("<<<<< UnmountDevice")
 
 	var respMount []*model.Mount
-	err := chapiClient.GetMounts(&respMount, GetSerialNumber(volume.SerialNumber))
+	err := chapiClient.GetMounts(&respMount, volume.SerialNumber)
 	if err != nil && !(strings.Contains(err.Error(), "object was not found")) {
 		return err
 	}
 	if respMount != nil {
 		for _, mount := range respMount {
 			log.Tracef("perform an unmount on the host with %#v", mount)
-			if mount.Device.SerialNumber == GetSerialNumber(volume.SerialNumber) {
+			if mount.Device.SerialNumber == volume.SerialNumber {
 				log.Tracef("Device to ummount found :%s", mount.Mountpoint)
 				var respMount model.Mount
 				err = chapiClient.Unmount(mount, &respMount)

--- a/chapi/chapiclient_linux.go
+++ b/chapi/chapiclient_linux.go
@@ -65,11 +65,6 @@ func NewChapiClientWithTimeout(timeout time.Duration) (*Client, error) {
 	return chapiClient, nil
 }
 
-// GetSerialNumber returns the volume serial number as per platform format
-func GetSerialNumber(serialNumber string) string {
-	return linux.GetLinuxSerialNumber(serialNumber)
-}
-
 // NewChapiClient returns the chapi client that communicates over the required unix socket(per process or common service)
 func NewChapiClient() (*Client, error) {
 	var chapiClient *Client

--- a/chapi/chapiclient_windows.go
+++ b/chapi/chapiclient_windows.go
@@ -114,11 +114,6 @@ func (chapiClient *Client) GetAccessKey() (string, error) {
 	return accessKey, nil
 }
 
-// GetSerialNumber returns the volume serial number as per platform format
-func GetSerialNumber(serialNumber string) string {
-	return serialNumber
-}
-
 // NewChapiClient returns the chapi client that communicates over the required unix socket(per process or common service)
 func NewChapiClient() (*Client, error) {
 	var chapiClient *Client

--- a/chapi/chapidriver_linux.go
+++ b/chapi/chapidriver_linux.go
@@ -163,7 +163,7 @@ func (driver *LinuxDriver) GetHostNameAndDomain() ([]string, error) {
 
 // CreateDevices will create devices on this host based on the volume details provided
 func (driver *LinuxDriver) CreateDevices(volumes []*model.Volume) ([]*model.Device, error) {
-	return linux.CreateNimbleDevices(volumes)
+	return linux.CreateLinuxDevices(volumes)
 }
 
 func (driver *LinuxDriver) GetDevice(volume *model.Volume) (*model.Device, error) {
@@ -219,7 +219,7 @@ func (driver *LinuxDriver) GetMounts(serialNumber string) ([]*model.Mount, error
 	log.Trace(">>>>> GetMounts, serialNumber: ", serialNumber)
 	defer log.Trace("<<<<< GetMounts")
 
-	devices, err := linux.GetNimbleDmDevices(false, serialNumber, "")
+	devices, err := linux.GetLinuxDmDevices(false, serialNumber, "")
 	if err != nil {
 		return nil, err
 	}

--- a/chapi/handler_linux.go
+++ b/chapi/handler_linux.go
@@ -137,15 +137,15 @@ func getChapInfo(w http.ResponseWriter, r *http.Request) {
 //@Router /hosts/{id}/devices [get]
 func getDevices(w http.ResponseWriter, r *http.Request) {
 	function := func() (interface{}, error) {
-		return linux.GetNimbleDmDevices(false, "", "")
+		return linux.GetLinuxDmDevices(false, "", "")
 	}
 	handleRequest(function, "getDevices", w, r)
 }
 
-// Create nimble device with attributes passed in the body of the http request
+// Create linux device with attributes passed in the body of the http request
 //@APIVersion 1.0.0
 //@Title createDevices
-//@Description create nimble devices for the VolumeInfos passed
+//@Description create linux devices for the VolumeInfos passed
 //@Accept json
 //@Resource /devices
 //@Success 200 {array} model.Devices
@@ -263,7 +263,7 @@ func deleteDevice(w http.ResponseWriter, r *http.Request) {
 // GetDeviceForSerialNumber get the device for that serialnumber
 //@APIVersion 1.0.0
 //@Title getDeviceForSerialNumber
-//@Description get Nimble Device for host id=id and device serialnumber=serialnumber
+//@Description get linux device for host id=id and device serialnumber=serialnumber
 //@Accept json
 //@Resource /devices
 //@Success 200 {array} model.Device
@@ -280,7 +280,7 @@ func getDeviceForSerialNumber(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	devices, err := linux.GetNimbleDmDevices(false, serialnumber, "")
+	devices, err := linux.GetLinuxDmDevices(false, serialnumber, "")
 	if err != nil {
 		handleError(w, chapiResp, err, http.StatusInternalServerError)
 		return
@@ -300,7 +300,7 @@ func getDeviceForSerialNumber(w http.ResponseWriter, r *http.Request) {
 
 //@APIVersion 1.0.0
 //@Title getPartitionsForDevice
-//@Description get all partitions for a Nimble Device fpr host id=id and device serialnumber=serialnumber
+//@Description get all partitions for a linux device for host id=id and device serialnumber=serialnumber
 //@Accept json
 //@Resource /partitions
 //@Success 200 {array} model.DevicePartitions
@@ -317,7 +317,7 @@ func getPartitionsForDevice(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	devices, err := linux.GetNimbleDmDevices(false, serialnumber, "")
+	devices, err := linux.GetLinuxDmDevices(false, serialnumber, "")
 	if err != nil {
 		handleError(w, chapiResp, err, http.StatusInternalServerError)
 		return
@@ -395,7 +395,7 @@ func getMountForDevice(w http.ResponseWriter, r *http.Request) {
 	mountid := vars["mountid"]
 	serialNumber := vars["serialNumber"]
 
-	devices, err := linux.GetNimbleDmDevices(false, serialNumber, "")
+	devices, err := linux.GetLinuxDmDevices(false, serialNumber, "")
 	if err != nil {
 		handleError(w, chapiResp, err, http.StatusInternalServerError)
 		return
@@ -418,7 +418,7 @@ func getMountForDevice(w http.ResponseWriter, r *http.Request) {
 
 //@APIVersion 1.0.0
 //@Title CreateFileSystem on device
-//@Description create a filesysten for a Nimble Device for host id=id and device serialnumber=serialnumber
+//@Description create a filesysten for a linux device for host id=id and device serialnumber=serialnumber
 //@Accept json
 //@Resource /devices/{serialnumber}/{filesystem}
 //@Success 200 {array} linux.CreateFileSystem
@@ -450,7 +450,7 @@ func createFileSystemOnDevice(w http.ResponseWriter, r *http.Request) {
 
 //@APIVersion 1.0.0
 //@Title  Mount  device to the host
-//@Description Mount an attached Nimble Device with a File System passed in the body on the host
+//@Description Mount an attached linux device with a File System passed in the body on the host
 //@Accept json
 //@Resource /mounts
 //@Success 200 {array} model.Mount
@@ -493,7 +493,7 @@ func mountDevice(w http.ResponseWriter, r *http.Request) {
 
 //@APIVersion 1.0.0
 //@Title  Unmount  device from the host
-//@Description Unmount an attached Nimble Device with a File System from the host
+//@Description Unmount an attached linux device with a File System from the host
 //@Accept json
 //@Resource /mounts
 //@Success 200 {array} model.Mount

--- a/dockerplugin/handler/get.go
+++ b/dockerplugin/handler/get.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"github.com/hpe-storage/common-host-libs/chapi"
 	"github.com/hpe-storage/common-host-libs/connectivity"
-	"github.com/hpe-storage/common-host-libs/dockerplugin/plugin"
 	"github.com/hpe-storage/common-host-libs/dockerplugin/provider"
 	log "github.com/hpe-storage/common-host-libs/logger"
 	"github.com/hpe-storage/common-host-libs/model"
@@ -74,7 +73,7 @@ func VolumeDriverGet(w http.ResponseWriter, r *http.Request) {
 		}
 		var respMount []*model.Mount
 
-		err = chapiClient.GetMounts(&respMount, plugin.GetDeviceSerialNumber(volumeResp.Volume.SerialNumber))
+		err = chapiClient.GetMounts(&respMount, volumeResp.Volume.SerialNumber)
 		if err != nil && !(strings.Contains(err.Error(), "object was not found")) {
 			vr := VolumeResponse{Err: err.Error()}
 			json.NewEncoder(w).Encode(vr)
@@ -89,7 +88,7 @@ func VolumeDriverGet(w http.ResponseWriter, r *http.Request) {
 
 func setVolumeStatus(respMount []*model.Mount, volumeResp *VolumeResponse) {
 	for _, mount := range respMount {
-		if mount.Device.SerialNumber == plugin.GetDeviceSerialNumber(volumeResp.Volume.SerialNumber) {
+		if mount.Device.SerialNumber == volumeResp.Volume.SerialNumber {
 			log.Trace("Mount Point found ", mount.Mountpoint)
 			volumeResp.Volume.MountPoint = mount.Mountpoint
 			if mount.Device != nil && mount.Device.AltFullPathName != "" {

--- a/dockerplugin/handler/mount.go
+++ b/dockerplugin/handler/mount.go
@@ -133,7 +133,7 @@ func VolumeDriverMount(w http.ResponseWriter, r *http.Request) {
 	log.Trace("retrieved volume response from container provider for volume: %+v", volume)
 
 	//4.  Get mounts from host
-	err = chapiClient.GetMounts(&respMount, plugin.GetDeviceSerialNumber(volume.SerialNumber))
+	err = chapiClient.GetMounts(&respMount, volume.SerialNumber)
 	if err != nil && !(strings.Contains(err.Error(), "object was not found")) {
 		mr = MountResponse{Err: err.Error()}
 		json.NewEncoder(w).Encode(mr)
@@ -464,7 +464,7 @@ func cleanupStaleMounts(containerProviderClient *connectivity.Client, chapiClien
 	}
 	log.Tracef("volumeInfo is %+v", volumeInfo)
 	// get the mounts of the volumes's serial number
-	_ = chapiClient.GetMounts(&respMount, plugin.GetDeviceSerialNumber(volumeInfo.SerialNumber))
+	_ = chapiClient.GetMounts(&respMount, volumeInfo.SerialNumber)
 	if respMount == nil || len(respMount) == 0 {
 		log.Tracef("no existing stale mounts found for volume %s, continue with mount", volumeInfo.Name)
 		return

--- a/dockerplugin/handler/path.go
+++ b/dockerplugin/handler/path.go
@@ -73,7 +73,7 @@ func VolumeDriverPath(w http.ResponseWriter, r *http.Request) {
 	}
 
 	//2. get mount for the volume object obtained from array
-	err = chapiClient.GetMounts(&respMount, plugin.GetDeviceSerialNumber(volResp.Volume.SerialNumber))
+	err = chapiClient.GetMounts(&respMount, volResp.Volume.SerialNumber)
 	if err != nil && !(strings.Contains(err.Error(), "object was not found")) {
 		mr = MountResponse{Err: err.Error()}
 		json.NewEncoder(w).Encode(mr)

--- a/dockerplugin/plugin/plugin_linux.go
+++ b/dockerplugin/plugin/plugin_linux.go
@@ -120,18 +120,12 @@ func excludeMountDirFromUpdateDb() error {
 	return linux.ExcludeMountDirFromUpdateDb(MountDir)
 }
 
-//GetDeviceSerialNumber :  Get the host device serial number from the volume SN
-// TODO: move this to linux chapi, client should not be doing these platform specific tweaks
-func GetDeviceSerialNumber(arraySn string) string {
-	log.Tracef("GetDeviceSerialNumber called with %s", arraySn)
-	return "2" + arraySn
-}
-
 // set default filesystem
 func setDefaultFilesystem(reqOpts map[string]interface{}) (err error) {
 	// dont need to set the default filesystem for linux.
 	return nil
 }
+
 func setDefaultVolumeDir(reqOpts map[string]interface{}) (err error) {
 	// dont need to se the default here for linux
 	return nil

--- a/dockerplugin/plugin/plugin_windows.go
+++ b/dockerplugin/plugin/plugin_windows.go
@@ -3,9 +3,6 @@
 package plugin
 
 import (
-
-
-
 	log "github.com/hpe-storage/common-host-libs/logger"
 	"github.com/hpe-storage/common-host-libs/util"
 	"github.com/hpe-storage/common-host-libs/windows"
@@ -80,17 +77,11 @@ func PreparePluginSocket() (listner net.Listener, err error) {
 	// local listen
 	listner, err = net.Listen(windows.Proto, windows.Hostname+":"+windows.PluginListenPort)
 	if err != nil {
-		log.Fatal("Listen err on http port %s, err %s:", windows.PluginListenPort,err.Error())
+		log.Fatal("Listen err on http port %s, err %s:", windows.PluginListenPort, err.Error())
 		return nil, err
 	}
 
 	return listner, nil
-}
-
-//GetDeviceSerialNumber :  Get the host device serial Number from the Volume SN
-func GetDeviceSerialNumber(arraySn string) string {
-	log.Tracef("GetDeviceSerialNumber called with %s", arraySn)
-	return arraySn
 }
 
 // set default filesystem

--- a/linux/device.go
+++ b/linux/device.go
@@ -22,27 +22,26 @@ import (
 )
 
 const (
-	dmsetupcommand      = "dmsetup"
-	majorMinorPattern   = "(.*)\\((?P<Major>\\d+),\\s+(?P<Minor>\\d+)\\)"
-	errorMapPattern     = "((?P<mapname>.*):.*error)"
-	dmPrefix            = "dm-"
-	serialNumberPattern = "2[a-f0-9]{16}6c9ce9[a-f0-9]{10}"
-	dmUUIDdFormat       = "/sys/block/dm-%s/dm/uuid"
-	dmNameFormat        = "/sys/block/dm-%s/dm/name"
-	dmSizeFormat        = "/sys/block/dm-%s/size"
-	devMapperPath       = "/dev/mapper/"
-	failedDevPath       = "failed to get device path"
-	notBlockDevice      = "not a block device"
-	deviceDoesNotExist  = "No such device or address"
-	noFileOrDirErr      = "No such file or directory"
-	offlinePathString   = "/sys/block/%s/device/state"
-	deletePathString    = "/sys/block/%s/device/delete"
-	sysBlockHolders     = "/sys/block/%s/holders/"
-	holderPattern       = "^.*dm-"
-	countdownTicker     = 5
-	sectorstoMiBFactor  = 2 * 1024
-	procScsiPath        = "/proc/scsi/scsi"
-	procScsiPathLocal   = "/proc_local/scsi/scsi"
+	dmsetupcommand     = "dmsetup"
+	majorMinorPattern  = "(.*)\\((?P<Major>\\d+),\\s+(?P<Minor>\\d+)\\)"
+	errorMapPattern    = "((?P<mapname>.*):.*error)"
+	dmPrefix           = "dm-"
+	dmUUIDdFormat      = "/sys/block/dm-%s/dm/uuid"
+	dmNameFormat       = "/sys/block/dm-%s/dm/name"
+	dmSizeFormat       = "/sys/block/dm-%s/size"
+	devMapperPath      = "/dev/mapper/"
+	failedDevPath      = "failed to get device path"
+	notBlockDevice     = "not a block device"
+	deviceDoesNotExist = "No such device or address"
+	noFileOrDirErr     = "No such file or directory"
+	offlinePathString  = "/sys/block/%s/device/state"
+	deletePathString   = "/sys/block/%s/device/delete"
+	sysBlockHolders    = "/sys/block/%s/holders/"
+	holderPattern      = "^.*dm-"
+	countdownTicker    = 5
+	sectorstoMiBFactor = 2 * 1024
+	procScsiPath       = "/proc/scsi/scsi"
+	procScsiPathLocal  = "/proc_local/scsi/scsi"
 	// HCTL format in /proc/scsi/scsi
 	// eg Host: scsi7 Channel: 00 Id: 00 Lun: 00
 	procScsiHctlPattern = "Host:\\s+scsi(?P<h>\\d+)\\s+Channel:\\s+(?P<c>\\d+)\\s+Id:\\s+(?P<t>\\d+)\\s+Lun:\\s+(?P<l>\\d+)"
@@ -52,10 +51,9 @@ const (
 )
 
 var (
-	deletingDevices     DeletingDevices
-	procScsiHctlRegex   = regexp.MustCompile(procScsiHctlPattern)
-	serialNumberMatcher = regexp.MustCompile(serialNumberPattern)
-	errorMapRegex       = regexp.MustCompile(errorMapPattern)
+	deletingDevices   DeletingDevices
+	procScsiHctlRegex = regexp.MustCompile(procScsiHctlPattern)
+	errorMapRegex     = regexp.MustCompile(errorMapPattern)
 )
 
 // DeletingDevices represents serial numbers of devices being deleted
@@ -159,6 +157,17 @@ func GetDmDeviceFromSerial(serial string) (*model.Device, error) {
 	device := &model.Device{SerialNumber: serial}
 	result := util.FindStringSubmatchMap(listOut[0], r)
 
+	// if user_friendly_names is disabled, then get the actual mpath serial(with scsi-id prefix)
+	if strings.Contains(mapname, serial) {
+		fileName := fmt.Sprintf(dmUUIDdFormat, result["minor"])
+		mpathSerialNumber, err := util.FileReadFirstLine(fileName)
+		if err != nil {
+			log.Warnf("unable to retrieve device info from %s, err %s", fileName, err.Error())
+			return nil, err
+		}
+		mapname = strings.TrimPrefix(mpathSerialNumber, "mpath-")
+	}
+
 	// path name in the format of /dev/dm-<minor>
 	path := "/dev/" + dmPrefix + string(result["minor"])
 	device.Pathname = path
@@ -169,11 +178,11 @@ func GetDmDeviceFromSerial(serial string) (*model.Device, error) {
 	return device, nil
 }
 
-// GetNimbleDmDevices : Gets the list of Linux Multipath Devices
+// GetLinuxDmDevices : Gets the list of Linux Multipath Devices
 // nolint : gocyclo
-func GetNimbleDmDevices(needActivePath bool, serialNumber, lunID string) (a []*model.Device, err error) {
-	log.Tracef(">>>>>> GetNimbleDmDevices called with %s and lunID %s", serialNumber, lunID)
-	defer log.Trace("<<<<<< GetNimbleDmDevices")
+func GetLinuxDmDevices(needActivePath bool, serialNumber, lunID string) (a []*model.Device, err error) {
+	log.Tracef(">>>>>> GetLinuxDmDevices called with %s and lunID %s", serialNumber, lunID)
+	defer log.Trace("<<<<<< GetLinuxDmDevices")
 	args := []string{"ls", "--target", "multipath"}
 	out, _, err := util.ExecCommandOutput(dmsetupcommand, args)
 	if err != nil {
@@ -218,26 +227,17 @@ func GetNimbleDmDevices(needActivePath bool, serialNumber, lunID string) (a []*m
 		}
 		// trim mpath- prefix from uuid read from /sys/block/dm-x/dm/uuid
 		mpathSerialNumber = strings.TrimPrefix(mpathSerialNumber, "mpath-")
+		// truncate scsi-id prefix added by multipathd(2 for EUI and 3 for NAA ID types)
+		mpathSerialNumber = mpathSerialNumber[1:]
 		if serialNumber != "" {
-			if !strings.Contains(mpathSerialNumber, serialNumber) {
+			if !strings.EqualFold(mpathSerialNumber, serialNumber) {
 				log.Tracef("serialNumber %s not match with mpathSerialNumber, %s continuing..", mpathSerialNumber, serialNumber)
 				continue
 			}
 		}
 
-		var serialNumberMatcher *regexp.Regexp
-		if serialNumber == "" {
-			serialNumberMatcher, err = regexp.Compile(serialNumberPattern)
-		} else {
-			serialNumberMatcher, err = regexp.Compile(serialNumber)
-		}
-		if err != nil {
-			return nil, fmt.Errorf("unable to compile regexp with %s", serialNumber)
-		}
-		if serialNumberMatcher.MatchString(mpathSerialNumber) {
-			listSerial := serialNumberMatcher.FindString(mpathSerialNumber)
-			log.Debugf("SerialNumber Matched :%s", listSerial)
-			device.SerialNumber = listSerial
+		if serialNumber == "" || strings.EqualFold(mpathSerialNumber, serialNumber) {
+			device.SerialNumber = mpathSerialNumber
 
 			sizeInMiB, err := getSizeOfDeviceInMiB(result["Minor"], device)
 			if err != nil {
@@ -401,11 +401,11 @@ func rescanLoginVolume(volume *model.Volume) error {
 	return nil
 }
 
-// CreateNimbleDevice : attaches and creates a new nimble device
+// CreateLinuxDevice : attaches and creates a new linux device
 // nolint: gocyclo
-func createNimbleDevice(volume *model.Volume) (dev *model.Device, err error) {
-	log.Debugf(">>>> createNimbleDevice called with volume %s serialNumber %s and lunID %s", volume.Name, volume.SerialNumber, volume.LunID)
-	defer log.Debug("<<<<< createNimbleDevice")
+func createLinuxDevice(volume *model.Volume) (dev *model.Device, err error) {
+	log.Debugf(">>>> createLinuxDevice called with volume %s serialNumber %s and lunID %s", volume.Name, volume.SerialNumber, volume.LunID)
+	defer log.Debug("<<<<< createLinuxDevice")
 	// Rescan and detect the newly attached volume
 	err = rescanLoginVolume(volume)
 	if err != nil {
@@ -417,7 +417,7 @@ func createNimbleDevice(volume *model.Volume) (dev *model.Device, err error) {
 	// Start a Countdown ticker
 	var devices []*model.Device
 	for i := 0; i <= countdownTicker; i++ {
-		devices, err = GetNimbleDmDevices(true, GetLinuxSerialNumber(volume.SerialNumber), volume.LunID)
+		devices, err = GetLinuxDmDevices(true, volume.SerialNumber, volume.LunID)
 		if err != nil {
 			return nil, err
 		}
@@ -427,7 +427,7 @@ func createNimbleDevice(volume *model.Volume) (dev *model.Device, err error) {
 				continue
 			}
 			// Match SerialNumber
-			if d.SerialNumber == GetLinuxSerialNumber(volume.SerialNumber) {
+			if d.SerialNumber == volume.SerialNumber {
 				log.Debugf("Found device with matching SerialNumber:%s map %s and slaves %+v", d.SerialNumber, d.AltFullPathName, d.Slaves)
 				return d, nil
 			}
@@ -611,7 +611,7 @@ func handleRemappedLun(volume *model.Volume) (err error) {
 			continue
 		}
 		// cleanup multipath device and all its paths, as we found its remapped with different LUN underneath
-		cleanupUnmappedDevice(GetLinuxSerialNumber(oldSerial), volume.LunID)
+		cleanupUnmappedDevice(oldSerial, volume.LunID)
 		// perform SCSI lun rescan to discover new volume paths
 		if strings.EqualFold(volume.AccessProtocol, "fc") {
 			RescanFcTarget(l)
@@ -639,7 +639,7 @@ func cleanupUnmappedDevice(oldSerial string, volumelunID string) error {
 	defer log.Traceln("<<< cleanupUnmappedDevice")
 	var devices []*model.Device
 	var err error
-	devices, err = GetNimbleDmDevices(false, oldSerial, "")
+	devices, err = GetLinuxDmDevices(false, oldSerial, "")
 	if err != nil {
 		log.Errorf("error occurred while getting unmapped device for serial %s, err %s", oldSerial, err.Error())
 		return err
@@ -696,7 +696,7 @@ func cleanupUnmappedDevice(oldSerial string, volumelunID string) error {
 							continue
 						}
 						// check for serial number from vpd page before deleting
-						if GetLinuxSerialNumber(currentSerial) == oldSerial {
+						if currentSerial == oldSerial {
 							deletePathByHctl(h, c, t, l)
 						}
 					}
@@ -869,7 +869,7 @@ func GetDeviceFromVolume(vol *model.Volume) (*model.Device, error) {
 	log.Tracef(">>>>> GetDeviceFromVolume for serial %s", vol.SerialNumber)
 	defer log.Trace("<<<<< GetDeviceFromVolume")
 
-	devices, err := GetNimbleDmDevices(false, vol.SerialNumber, vol.LunID)
+	devices, err := GetLinuxDmDevices(false, vol.SerialNumber, vol.LunID)
 	if err != nil {
 		return nil, err
 	}
@@ -879,10 +879,10 @@ func GetDeviceFromVolume(vol *model.Volume) (*model.Device, error) {
 	return devices[0], nil
 }
 
-//CreateNimbleDevices : attached and creates nimble devices to host
-func CreateNimbleDevices(vols []*model.Volume) (devs []*model.Device, err error) {
-	log.Tracef(">>>>> CreateNimbleDevices")
-	defer log.Trace("<<<<< CreateNimbleDevices")
+//CreateLinuxDevices : attached and creates linux devices to host
+func CreateLinuxDevices(vols []*model.Volume) (devs []*model.Device, err error) {
+	log.Tracef(">>>>> CreateLinuxDevices")
+	defer log.Trace("<<<<< CreateLinuxDevices")
 
 	var devices []*model.Device
 	for _, vol := range vols {
@@ -890,7 +890,7 @@ func CreateNimbleDevices(vols []*model.Volume) (devs []*model.Device, err error)
 		if vol.AccessProtocol == iscsi && (vol.DiscoveryIP == "" || vol.Iqn == "") && len(vol.DiscoveryIPs) == 0 {
 			return nil, fmt.Errorf("cannot discover without IP. Please sanity check host OS and array IP configuration, network, netmask and gateway")
 		}
-		device, err := createNimbleDevice(vol)
+		device, err := createLinuxDevice(vol)
 		if err != nil {
 			log.Errorf("unable to create device for volume %v with IQN %v", vol.Name, vol.Iqn)
 			// If we encounter an error, there may be some devices created and some not.
@@ -906,10 +906,6 @@ func CreateNimbleDevices(vols []*model.Volume) (devs []*model.Device, err error)
 // OfflineDevice : offline all the scsi paths for the multipath device
 func OfflineDevice(dev *model.Device) (err error) {
 	log.Tracef("OfflineDevice called with %s", dev.SerialNumber)
-	//validate nimble device
-	if serialNumberMatcher.MatchString(dev.SerialNumber) == false {
-		return fmt.Errorf("device %s is not a nimble device", dev.SerialNumber)
-	}
 	// perform offline scsi paths of the multipath device
 	if dev.SerialNumber == "" {
 		return fmt.Errorf("no serialNumber of device %v present, failing delete", dev)
@@ -1067,11 +1063,6 @@ func getDeviceHolders(dev *model.Device) (h string, err error) {
 	}
 
 	return holder, nil
-}
-
-//GetLinuxSerialNumber :  Get the Linux Serial Number from the Array Sn
-func GetLinuxSerialNumber(arraySn string) string {
-	return "2" + arraySn
 }
 
 // RescanSize performs size rescan of all scsi devices on host and updates applicable multipath devices

--- a/linux/mount.go
+++ b/linux/mount.go
@@ -208,7 +208,7 @@ func CreateFileSystemOnDevice(serialnumber string, fileSystemType string) (dev *
 	log.Tracef("CreateFileSystemOnDevice called with :%s %s", serialnumber, fileSystemType)
 	var devices []*model.Device
 	for i := 1; i <= countdownTicker; i++ {
-		devices, err = GetNimbleDmDevices(true, serialnumber, "")
+		devices, err = GetLinuxDmDevices(true, serialnumber, "")
 		if err != nil {
 			log.Debugf("error to retrieve active paths for %s, retrying, count=%d", serialnumber, i)
 			continue

--- a/linux/multipath.go
+++ b/linux/multipath.go
@@ -15,10 +15,11 @@ import (
 )
 
 var (
-	showPathsFormat  = []string{"show", "paths", "format", "%w %d %t %i %o %T %c %s %m"}
-	showMapsFormat   = []string{"show", "maps", "format", "%w %d %n %s"}
-	orphanPathRegexp = regexp.MustCompile(orphanPathsPattern)
-	multipathMutex   sync.Mutex
+	showPathsFormat      = []string{"show", "paths", "format", "%w %d %t %i %o %T %c %s %m"}
+	showMapsFormat       = []string{"show", "maps", "format", "%w %d %n %s"}
+	orphanPathRegexp     = regexp.MustCompile(getOrphanPathsPattern())
+	multipathMutex       sync.Mutex
+	deviceVendorPatterns = []string{"Nimble", "3PARdata"}
 )
 
 const (
@@ -26,9 +27,14 @@ const (
 	MultipathConf = "/etc/multipath.conf"
 	// MultipathBindings bindings file for multipathd
 	MultipathBindings  = "/etc/multipath/bindings"
-	orphanPathsPattern = ".*(?P<host>\\d+):(?P<channel>\\d+):(?P<target>\\d+):(?P<lun>\\d+).*Nimble.*orphan"
+	orphanPathsPattern = ".*(?P<host>\\d+):(?P<channel>\\d+):(?P<target>\\d+):(?P<lun>\\d+).*(REPLACE_VENDOR).*orphan"
 	maxTries           = 3
 )
+
+func getOrphanPathsPattern() string {
+	vendorPattern := strings.Join(deviceVendorPatterns, "|")
+	return strings.Replace(orphanPathsPattern, "REPLACE_VENDOR", vendorPattern, -1)
+}
 
 // MultipathdShowMaps output
 func MultipathdShowMaps(serialNumber string) (a []string, err error) {

--- a/linux/multipath.go
+++ b/linux/multipath.go
@@ -469,7 +469,7 @@ func multipathGetPathsOfDevice(dev *model.Device, needActivePath bool) (paths []
 			if !needActivePath {
 				log.Tracef("needActive %v dev(%s) dm_st(%s) hcil(%s) for uuid(%s)", needActivePath, entry[1], entry[2], entry[3], entry[0])
 				path := &model.PathInfo{
-					UUID:     entry[0],
+					UUID:     entry[0][1:],
 					Device:   entry[1],
 					DmState:  entry[2],
 					Hcil:     entry[3],
@@ -480,7 +480,7 @@ func multipathGetPathsOfDevice(dev *model.Device, needActivePath bool) (paths []
 			} else if len(entry) >= 5 && entry[2] == model.ActiveState.String() && entry[5] == "ready" {
 				log.Tracef("needActive %v dev(%s) chk_st(%s) dm_st(%s) for uuid(%s)", needActivePath, entry[1], entry[5], entry[2], entry[0])
 				path := &model.PathInfo{
-					UUID:     entry[0],
+					UUID:     entry[0][1:],
 					Device:   entry[1],
 					DmState:  entry[2],
 					Hcil:     entry[3],

--- a/tunelinux/config.go
+++ b/tunelinux/config.go
@@ -266,7 +266,7 @@ func GetRecommendations() (settings []*Recommendation, err error) {
 	var fcRecommendations []*Recommendation
 
 	// Get all nimble devices
-	devices, err := linux.GetNimbleDmDevices(false, "", "")
+	devices, err := linux.GetLinuxDmDevices(false, "", "")
 	if err != nil {
 		log.Error("Unable to get Nimble devices ", err.Error())
 		return nil, err

--- a/tunelinux/config/multipath.conf.generic
+++ b/tunelinux/config/multipath.conf.generic
@@ -15,6 +15,10 @@ blacklist_exceptions {
         vendor  "Nimble"
         product "Server"
     }
+    device {
+        vendor  "3PARdata"
+        product "VV"
+    }
 }
 devices {
     device {

--- a/tunelinux/config/multipath.conf.upstream
+++ b/tunelinux/config/multipath.conf.upstream
@@ -17,6 +17,10 @@ blacklist_exceptions {
         vendor  "Nimble"
         product "Server"
     }
+    device {
+        vendor  "3PARdata"
+        product "VV"
+    }
 }
 devices {
     device {

--- a/tunelinux/disk.go
+++ b/tunelinux/disk.go
@@ -132,7 +132,7 @@ func GetDeviceRecommendations(devices []*model.Device) (settings []*Recommendati
 
 func updateUdevRule() (err error) {
 	// Get all nimble devices
-	devices, err := linux.GetNimbleDmDevices(true, "", "")
+	devices, err := linux.GetLinuxDmDevices(true, "", "")
 	if err != nil {
 		log.Error("Unable to get Nimble devices ", err.Error())
 		return err

--- a/tunelinux/iscsi.go
+++ b/tunelinux/iscsi.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"github.com/hpe-storage/common-host-libs/linux"
 	log "github.com/hpe-storage/common-host-libs/logger"
-	"github.com/hpe-storage/common-host-libs/model"
 	"github.com/hpe-storage/common-host-libs/util"
 	"io/ioutil"
 	"os"
@@ -306,7 +305,7 @@ func getIscsiFormattedParam(parameter string) (formattedParam string, err error)
 func updateIscsiSessionParameters(remediations []*Recommendation) (err error) {
 	var formattedParam string
 	// Get logged-in iSCSi sessions
-	iscsiTargets, err := linux.GetIscsiTargets()
+	iscsiTargets, err := linux.GetLoggedInIscsiTargets()
 	if err != nil {
 		log.Error("Unable to get logged-in iscsi session to update recommendations, error: ", err.Error())
 		return err
@@ -316,26 +315,26 @@ func updateIscsiSessionParameters(remediations []*Recommendation) (err error) {
 		for _, iscsiTarget := range iscsiTargets {
 			formattedParam, err = getIscsiFormattedParam(remediation.Parameter)
 			if err != nil {
-				log.Error("Unable to get formatted param for ", remediation.Parameter, " target: ", iscsiTarget.Name, "error: ", err.Error())
+				log.Error("Unable to get formatted param for ", remediation.Parameter, " target: ", iscsiTarget, "error: ", err.Error())
 				// continue with other remediations
 				continue
 			}
-			err = SetIscsiSessionParam(*iscsiTarget, formattedParam, remediation.Recommendation)
+			err = SetIscsiSessionParam(iscsiTarget, formattedParam, remediation.Recommendation)
 			if err != nil {
-				log.Error("Unable to update iscsi session param ", remediation.Parameter, " target: ", iscsiTarget.Name, "error: ", err.Error())
+				log.Error("Unable to update iscsi session param ", remediation.Parameter, " target: ", iscsiTarget, "error: ", err.Error())
 				// continue with other remediations
 				continue
 			}
-			log.Info("Successfully updated iscsi session param ", remediation.Parameter, " target: ", iscsiTarget.Name)
+			log.Info("Successfully updated iscsi session param ", remediation.Parameter, " target: ", iscsiTarget)
 		}
 	}
 	return nil
 }
 
 // SetIscsiSessionParam set parameter value for logged-in iscsi session
-func SetIscsiSessionParam(target model.IscsiTarget, parameter string, value string) (err error) {
-	log.Trace("SetIscsiSessionParam called with ", target.Name, " param: ", parameter, " value: ", value)
-	args := []string{"--mode", "node", "--op", "update", "-T", target.Name, "--portal", target.Address, "--name", parameter, "--value", value}
+func SetIscsiSessionParam(target string, parameter string, value string) (err error) {
+	log.Trace("SetIscsiSessionParam called with ", target, " param: ", parameter, " value: ", value)
+	args := []string{"--mode", "node", "--op", "update", "-T", target, "--name", parameter, "--value", value}
 	_, _, err = util.ExecCommandOutput("iscsiadm", args)
 	if err != nil {
 		err = errors.New("unable to set iSCSI param value for " + parameter + " value " + value + "error: " + err.Error())
@@ -412,7 +411,7 @@ func ConfigureIscsi() (err error) {
 	if err != nil {
 		return err
 	}
-  
+
 	// Start service
 	err = linux.ServiceCommand(iscsi, "start")
 	if err != nil {
@@ -421,5 +420,3 @@ func ConfigureIscsi() (err error) {
 
 	return nil
 }
-
-


### PR DESCRIPTION
* Problem:
  * serial_number provided to chapi is assumed to be with scsi-id type prefix 2 (mpath)
  * iscsi targets are looked up by nimble specific patterns and device filtering used nimble vendor types
  * dependency on /dev/disk/by-path symlinks for logged-in sessions, but group wide targets might be logged-in
  * without devices
* Implementation:
  * change to always assume serial number input to chapi is of volume serial number and same with returned types
  * only consider scsi-id type prefix during mpath comparisions, not store anywhere
  * add table for vendor patterns for device and target-iqn comparision and filtering
  * fix function names to be generic
* Testing: in-progress with CSI/FlexVolume drivers
* Review: gcostea, rkumar, sbyadarahalli
* Bug: https://nimblejira.nimblestorage.com/browse/NLT-
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>