### PR TITLE
chapi: avoid /proc/mounts due to duplicates

### DIFF
--- a/chapi/chapidriver_linux.go
+++ b/chapi/chapidriver_linux.go
@@ -290,7 +290,7 @@ func (driver *LinuxDriver) BindMount(mountPoint string, newMountPoint string, rb
 // BindUnmount unmounts the given bind mount
 func (driver *LinuxDriver) BindUnmount(mountPoint string) error {
 	log.Tracef(">>>>> BindUnmount, mountPoint: %s", mountPoint)
-	defer log.Trace("<<<<< BindMount")
+	defer log.Trace("<<<<< BindUnmount")
 
 	// Unmount given bind mount
 	return linux.RetryBindUnmount(mountPoint)

--- a/linux/mount.go
+++ b/linux/mount.go
@@ -26,6 +26,7 @@ var (
 	lsof                   = "lsof"
 	blkid                  = "blkid"
 	errCurrentlyMounted    = "is currently mounted"
+	procMounts             = "/proc/mounts"
 )
 
 // FsType indicates the filesystem type of mounted device
@@ -91,14 +92,16 @@ func GetMountPointsForDevices(devices []*model.Device) ([]*model.Mount, error) {
 
 	var mounts []*model.Mount
 	devToMounts := make(map[string][]string)
-	mountLines, err := util.FileGetStrings(procMounts)
+	var args []string
+	out, _, err := util.ExecCommandOutput(mountCommand, args)
 	if err != nil {
 		return nil, err
 	}
+	mountLines := strings.Split(out, "\n")
 	for _, line := range mountLines {
 		entry := strings.Fields(line)
-		if len(entry) > 2 {
-			devToMounts[entry[0]] = append(devToMounts[entry[0]], entry[1])
+		if len(entry) > 3 {
+			devToMounts[entry[0]] = append(devToMounts[entry[0]], entry[2])
 		}
 	}
 

--- a/linux/multipath.go
+++ b/linux/multipath.go
@@ -321,7 +321,7 @@ func multipathDisableQueuing(dev *model.Device) (err error) {
 	return nil
 }
 
-// multipathRemoveDmDevice : remove multipath device ps via multipathd
+// multipathRemoveDmDevice : remove multipath device ps via dmsetup
 func multipathRemoveDmDevice(dev *model.Device) (err error) {
 	log.Tracef(">>>>> multipathRemoveDmDevice called for %+v", dev)
 	defer log.Trace("<<<<< multipathRemoveDmDevice")
@@ -335,8 +335,8 @@ func multipathRemoveDmDevice(dev *model.Device) (err error) {
 			return err
 		}
 	}
-	args := []string{"remove", "map", dev.MpathName}
-	out, _, err := util.ExecCommandOutput(multipathd, args)
+	args := []string{"remove", "--force", dev.MpathName}
+	out, _, err := util.ExecCommandOutput(dmsetupcommand, args)
 	if err != nil {
 		return fmt.Errorf("failed to remove multipath map for %s. Error: %s", dev.MpathName, err.Error())
 	}

--- a/linux/multipath.go
+++ b/linux/multipath.go
@@ -228,7 +228,7 @@ func cleanupDeviceAndSlaves(dev *model.Device) (err error) {
 	// remove dm device
 	removeErr := multipathRemoveDmDevice(dev)
 	if removeErr != nil {
-		log.Error(err)
+		log.Error(removeErr.Error())
 		// proceed with the rest of the path cleanup nevertheless, as mpath might get deleted asynchronously
 	}
 
@@ -243,6 +243,7 @@ func cleanupDeviceAndSlaves(dev *model.Device) (err error) {
 		log.Debugf("volume scoped target %+v, initiating iscsi logout and delete", dev.IscsiTarget)
 		err = logoutAndDeleteIscsiTarget(dev)
 		if err != nil {
+			log.Error(err.Error())
 			return err
 		}
 	} else {
@@ -320,24 +321,10 @@ func multipathDisableQueuing(dev *model.Device) (err error) {
 	return nil
 }
 
-// multipathRemoveDmDevice : remove multipath device ps via dmsetup
+// multipathRemoveDmDevice : remove multipath device ps via multipathd
 func multipathRemoveDmDevice(dev *model.Device) (err error) {
 	log.Tracef(">>>>> multipathRemoveDmDevice called for %+v", dev)
 	defer log.Trace("<<<<< multipathRemoveDmDevice")
-
-	err = multipathRemoveMapDmSetup(dev)
-	if err != nil {
-		return fmt.Errorf("failed to remove multipath device %s. Error: %s ", dev.MpathName, err.Error())
-	}
-
-	log.Debugf("successfully removed the dm device %s", dev.MpathName)
-	return nil
-}
-
-// multipathRemoveMapDmSetup : remove multipath maps via dmsetup
-func multipathRemoveMapDmSetup(dev *model.Device) (err error) {
-	log.Tracef(">>>>> multipathRemoveMapDmSetup called for %+v", dev)
-	defer log.Trace("<<<<< multipathRemoveMapDmSetup")
 
 	multipathMutex.Lock()
 	defer multipathMutex.Unlock()
@@ -348,14 +335,16 @@ func multipathRemoveMapDmSetup(dev *model.Device) (err error) {
 			return err
 		}
 	}
-	args := []string{"remove", "--force", dev.MpathName}
-	out, _, err := util.ExecCommandOutput(dmsetupcommand, args)
+	args := []string{"remove", "map", dev.MpathName}
+	out, _, err := util.ExecCommandOutput(multipathd, args)
 	if err != nil {
 		return fmt.Errorf("failed to remove multipath map for %s. Error: %s", dev.MpathName, err.Error())
 	}
-	if out != "" && strings.Contains(out, deviceDoesNotExist) == false {
+	if out != "" && !strings.Contains(out, "ok") && !strings.Contains(out, deviceDoesNotExist) {
 		return fmt.Errorf("failed to remove device map for %s. Error: %s", dev.MpathName, out)
 	}
+
+	log.Debugf("successfully removed the dm device %s", dev.MpathName)
 	return nil
 }
 


### PR DESCRIPTION
* Problem:
  * When using chroot mechanism, both /var/lib/kubelet and /host will be mounted within container
  * This will cause duplicate mount entries in /proc/mounts leading confusion in mount cleanup.
  * Also, dmsetup remove is hanging within chroot.
* Implementation:
  * Use "mount" call to fetch mount points rather than /proc/mounts as its inconsistent. mount call always
  * yeilds without duplicates.
  * use multipathd remove instead of dmsetup remove to avoid hang issue.
* Testing: regression tests on RHEL 7.6, and pending on Ubuntu 16 and 18.
* Review: gcostea, rkumar
* Bug: https://nimblejira.nimblestorage.com/browse/NLT-
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>