### PR TITLE
common-host-libs: handle cases where hostnamectl and dmidecode are mi…

### DIFF
--- a/linux/system.go
+++ b/linux/system.go
@@ -18,6 +18,7 @@ const (
 	dmesgHypervisorPattern = "(Hypervisor.*)"
 	chasisPattern          = "Chassis:\\s*(?P<chassis>.*)"
 	hostnameCtl            = "hostnamectl"
+	dmiSysfsPath           = "/sys/firmware/dmi/tables/DMI"
 )
 
 func getSystemInfoByParamName(parameter string) (systemInfo string, err error) {
@@ -98,20 +99,11 @@ func GetProductName() (productName string, err error) {
 func IsVirtualMachine() (isVM bool, err error) {
 	var manufacturerName string
 	isVM = false
-	// try obtaining usign hostnamectl first if available on host
-	chassis, err := getSystemChassisInfo()
-	if err == nil {
-		if strings.EqualFold("vm", chassis) {
-			log.Trace("chassis info obtained using hostnamectl, running as a vm")
-			return true, nil
-		}
-		return false, nil
-	}
 	// fall back to get details using dmidecode
 	manufacturerName, err = GetManufacturer()
 	if err != nil {
-		// dmidecode can be missing, perform another best attempt to determine if running as vm using dmesg
-		lines, err2 := util.FileGetStringsWithPattern("/var/log/dmesg", dmesgHypervisorPattern)
+		// dmidecode can be missing, perform another best attempt to determine if running as vm using sysfs
+		lines, err2 := util.FileGetStringsWithPattern(dmiSysfsPath, hypervisorTypePattern)
 		if err2 != nil {
 			log.Error("unable to get system information using dmesg as well ", err2.Error())
 			// return original error with dmidecode
@@ -120,13 +112,14 @@ func IsVirtualMachine() (isVM bool, err error) {
 		if len(lines) > 0 {
 			isVM = true
 		}
+		log.Trace("DMI-SYSFS: System is running as a virtual machine")
 		return isVM, nil
 	}
 	// check if product name matches any of the hypervisor types(vmware, kvm or hyperV)
 	r := regexp.MustCompile(hypervisorTypePattern)
 	if r.MatchString(manufacturerName) {
 		isVM = true
-		log.Trace("System is running as a virtual machine")
+		log.Trace("DMI: System is running as a virtual machine")
 	}
 	return isVM, nil
 }

--- a/linux/system.go
+++ b/linux/system.go
@@ -105,7 +105,7 @@ func IsVirtualMachine() (isVM bool, err error) {
 		// dmidecode can be missing, perform another best attempt to determine if running as vm using sysfs
 		lines, err2 := util.FileGetStringsWithPattern(dmiSysfsPath, hypervisorTypePattern)
 		if err2 != nil {
-			log.Error("unable to get system information using dmesg as well ", err2.Error())
+			log.Error("unable to get system information using sysfs as well ", err2.Error())
 			// return original error with dmidecode
 			return false, errors.New("cannot determine if system is of type virtual machine, " + err.Error())
 		}


### PR DESCRIPTION
…ssing

* Problem:
  * We depend on hostnamectl and dmidecode to figure out if running on virtual machine
  * These tools are not available on some flavors(CoreOS) and deployment is failing.
* Implementation:
  * Fall back to the sysfs path that is used by dmidecode to figure out if running on VM.
  * Remove hostnamectl usage altogether as sysfs path seems to be universally available.
* Testing: tested on CentOS 7.6 and Ubuntu 18.04 and make sure parsing is working.
* Review: gcostea, rkumar
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>