### PR TITLE
linux: reload specific mpath on device resize

### DIFF
--- a/linux/device.go
+++ b/linux/device.go
@@ -1068,7 +1068,7 @@ func getDeviceHolders(dev *model.Device) (h string, err error) {
 // RescanSize performs size rescan of all scsi devices on host and updates applicable multipath devices
 // TODO: replace rescan-scsi-bus.sh dependency with manual rescan of scsi devices
 func RescanForCapacityUpdates(devicePath string) error {
-	log.Tracef(">>>>> RescanForCapacityUpdates")
+	log.Tracef(">>>>> RescanForCapacityUpdates called for %s", devicePath)
 	defer log.Traceln("<<<<< RescanForCapacityUpdates")
 
 	args := []string{"-s", "-m"}
@@ -1078,9 +1078,11 @@ func RescanForCapacityUpdates(devicePath string) error {
 	}
 
 	if devicePath != "" {
+		// multipathd takes either mpathx(without prefix) or /dev/dm-x as input
+		devicePath = strings.TrimPrefix(devicePath, "/dev/mapper/")
 		// reload multipath map to apply new size
-		args = []string{"-r", devicePath}
-		_, _, err = util.ExecCommandOutput("multipath", args)
+		args = []string{"reload", "map", devicePath}
+		_, _, err = util.ExecCommandOutput("multipathd", args)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
* Problem:
  * Currently we use "multipathd reconfigure" after device resize.
  * this causes all multipath tables to be reloaded causing delay
  * and sometimes doesn't complete before fsResize is called.
  * Also, "reconfigure" is async, so cannot guarantee table load
  * is complete before we return the  call.
* Implementation:
  * Reload specific device which was asked to expand.
* Testing: tested on Ubuntu 18.04 and CentOS 7.5 with both block and fs expand.
* Review: gcostea, rkumar
* Bug: https://nimblejira.nimblestorage.com/browse/NLT-
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>