### PR TITLE
multipathd reload doesn't update size of the map, use resize instead and error out on timeout errors.

### DIFF
--- a/linux/device.go
+++ b/linux/device.go
@@ -1081,10 +1081,13 @@ func RescanForCapacityUpdates(devicePath string) error {
 		// multipathd takes either mpathx(without prefix) or /dev/dm-x as input
 		devicePath = strings.TrimPrefix(devicePath, "/dev/mapper/")
 		// reload multipath map to apply new size
-		args = []string{"reload", "map", devicePath}
-		_, _, err = util.ExecCommandOutput("multipathd", args)
+		args = []string{"resize", "map", devicePath}
+		out, _, err := util.ExecCommandOutput("multipathd", args)
 		if err != nil {
 			return err
+		}
+		if strings.Contains(out, "timeout") {
+			return fmt.Errorf("failed to rescan device %s on resize, err: %s", devicePath, out)
 		}
 	}
 	return nil

--- a/linux/device.go
+++ b/linux/device.go
@@ -1086,7 +1086,7 @@ func RescanForCapacityUpdates(devicePath string) error {
 		if err != nil {
 			return err
 		}
-		if strings.Contains(out, "timeout") {
+		if !strings.Contains(out, "ok") {
 			return fmt.Errorf("failed to rescan device %s on resize, err: %s", devicePath, out)
 		}
 	}


### PR DESCRIPTION


Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>