### PR TITLE
storageprovider: Add support to edit volume properties

### DIFF
--- a/storageprovider/csp/container_storage_provider.go
+++ b/storageprovider/csp/container_storage_provider.go
@@ -462,7 +462,7 @@ func (provider *ContainerStorageProvider) ExpandVolume(id string, requestBytes i
 	return response, err
 }
 
-// EditVolume creates a volume on the CSP
+// EditVolume edits a volume on the CSP
 func (provider *ContainerStorageProvider) EditVolume(id string, opts map[string]interface{}) (*model.Volume, error) {
 	log.Tracef(">>>>> EditVolume, id: %s, opts: %v", id, opts)
 	defer log.Trace("<<<<< EditVolume")

--- a/storageprovider/csp/container_storage_provider.go
+++ b/storageprovider/csp/container_storage_provider.go
@@ -462,6 +462,36 @@ func (provider *ContainerStorageProvider) ExpandVolume(id string, requestBytes i
 	return response, err
 }
 
+// EditVolume creates a volume on the CSP
+func (provider *ContainerStorageProvider) EditVolume(id string, opts map[string]interface{}) (*model.Volume, error) {
+	log.Tracef(">>>>> EditVolume, id: %s, opts: %v", id, opts)
+	defer log.Trace("<<<<< EditVolume")
+
+	response := &model.Volume{}
+	var errorResponse *ErrorsPayload
+
+	volume := &model.Volume{
+		ID:     id,
+		Config: opts,
+	}
+
+	// Edit the volume on the array
+	status, err := provider.invoke(
+		&connectivity.Request{
+			Action:        "PUT",
+			Path:          fmt.Sprintf("/containers/v1/volumes/%s", id),
+			Payload:       &volume,
+			Response:      &response,
+			ResponseError: &errorResponse,
+		},
+	)
+	if errorResponse != nil {
+		return nil, handleError(status, errorResponse)
+	}
+
+	return response, err
+}
+
 // GetVolume will return information about the given volume
 func (provider *ContainerStorageProvider) GetVolume(id string) (*model.Volume, error) {
 	response := &model.Volume{}

--- a/storageprovider/fake/fake_storage_provider.go
+++ b/storageprovider/fake/fake_storage_provider.go
@@ -224,7 +224,7 @@ func (provider *StorageProvider) ExpandVolume(id string, requestBytes int64) (*m
 	return &fakeVolume, nil
 }
 
-// ExpandVolume will expand the fake volume to requested size
+// EditVolume will edit the fake volume with requested params
 func (provider *StorageProvider) EditVolume(id string, parameters map[string]interface{}) (*model.Volume, error) {
 	if _, ok := provider.volumes[id]; !ok {
 		return nil, fmt.Errorf("Could not find volume with id %s", id)

--- a/storageprovider/fake/fake_storage_provider.go
+++ b/storageprovider/fake/fake_storage_provider.go
@@ -44,9 +44,10 @@ func (provider *StorageProvider) CreateVolume(name, description string, size int
 		return nil, fmt.Errorf("Volume named %s already exists", name)
 	}
 	fakeVolume := model.Volume{
-		ID:   name,
-		Name: name,
-		Size: size,
+		ID:     name,
+		Name:   name,
+		Size:   size,
+		Config: opts,
 	}
 	provider.volumes[name] = fakeVolume
 	return &fakeVolume, nil
@@ -217,11 +218,22 @@ func (provider *StorageProvider) ExpandVolume(id string, requestBytes int64) (*m
 	if _, ok := provider.volumes[id]; !ok {
 		return nil, fmt.Errorf("Could not find volume with id %s", id)
 	}
-	fakeVolume := model.Volume{
-		ID:   id,
-		Size: requestBytes,
+	fakeVolume := provider.volumes[id]
+	// update volume, so that new size will be reflected
+	fakeVolume.Size = requestBytes
+	return &fakeVolume, nil
+}
+
+// ExpandVolume will expand the fake volume to requested size
+func (provider *StorageProvider) EditVolume(id string, parameters map[string]interface{}) (*model.Volume, error) {
+	if _, ok := provider.volumes[id]; !ok {
+		return nil, fmt.Errorf("Could not find volume with id %s", id)
 	}
-	// update volume in the map, so that new size will be reflected
-	provider.volumes[id] = fakeVolume
+
+	// update volume in the map, so that new properties will be reflected
+	fakeVolume := provider.volumes[id]
+	for key, value := range parameters {
+		fakeVolume.Config[key] = value
+	}
 	return &fakeVolume, nil
 }

--- a/storageprovider/fake/fake_storage_provider_test.go
+++ b/storageprovider/fake/fake_storage_provider_test.go
@@ -55,6 +55,14 @@ func TestPluginSuite(t *testing.T) {
 	}
 	assert.True(t, updatedVolume.Size == volume.Size*2)
 
+	editConfig := make(map[string]interface{})
+	editConfig["editme"] = "edited"
+	editedVolume, err := provider.EditVolume(volume.ID, editConfig)
+	if err != nil {
+		t.Fatal("Failed to edit volume")
+	}
+	assert.True(t, editedVolume.Config["editme"] == "edited")
+
 	// CloneVolume without a source snapshot ID will indirectly test snapshot creation
 	clone := createClone(t, provider, volume.ID, "", cloneSize)
 

--- a/storageprovider/storage_provider.go
+++ b/storageprovider/storage_provider.go
@@ -41,6 +41,7 @@ type StorageProvider interface {
 	GetSnapshots(sourceVolID string) ([]*model.Snapshot, error)
 	CreateSnapshot(name, description, sourceVolID string, opts map[string]interface{}) (*model.Snapshot, error)
 	DeleteSnapshot(id string) error
+	EditVolume(id string, opts map[string]interface{}) (*model.Volume, error)
 }
 
 // Credentials defines how a StorageProvider is accessed


### PR DESCRIPTION
* Problem:
  * Need api to edit volume properties to invoke CSP update volume.
* Implementation:
  * Added client api to invoke edit_volume with requested properties
* Testing: tested with volume-mutator
* Review: gcostea, rkumar
* Bug: https://nimblejira.nimblestorage.com/browse/NLT-
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>