### PR TITLE
chapi: add nfs mount endpoint

### DIFF
--- a/chapi/chapidriver.go
+++ b/chapi/chapidriver.go
@@ -18,6 +18,7 @@ type Driver interface {
 	DeleteDevice(device *model.Device) error
 	OfflineDevice(device *model.Device) error
 	MountDevice(device *model.Device, mountPoint string, mountOptions []string, fsOpts *model.FilesystemOpts) (*model.Mount, error) // Idempotent
+	MountNFSVolume(source string, target string, mountOptions []string) error                                                       // Idempotent
 	BindMount(mountPoint string, newMountPoint string, rbind bool) error                                                            // Idempotent
 	BindUnmount(mountPoint string) error                                                                                            // Idempotent
 	UnmountDevice(device *model.Device, mountPoint string) (*model.Mount, error)                                                    // Idempotent

--- a/chapi/chapidriver_darwin.go
+++ b/chapi/chapidriver_darwin.go
@@ -33,7 +33,7 @@ func (driver *MacDriver) GetMountOptions(device *model.Device, mountPoint string
 }
 
 // GetHostNetworks reports the networks on this host
-func (driver *MacDriver) GetHostNetworks() ([]*model.Network, error) {
+func (driver *MacDriver) GetHostNetworks() ([]*model.NetworkInterface, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -130,4 +130,9 @@ func (driver *MacDriver) BindUnmount(mountPoint string) error {
 // ExpandDevice will expand the given device/filesystem on the host
 func (driver *MacDriver) ExpandDevice(targetPath string, volAccessType model.VolumeAccessType) error {
 	return fmt.Errorf("not implemented")
+}
+
+// MountNFSVolume mounts NFS share onto given target path
+func (driver *MacDriver) MountNFSVolume(source string, targetPath string, mountOptions []string) error {
+	return nil
 }

--- a/chapi/chapidriver_fake.go
+++ b/chapi/chapidriver_fake.go
@@ -154,3 +154,8 @@ func (driver *FakeDriver) OfflineDevice(device *model.Device) error {
 func (driver *FakeDriver) ExpandDevice(targetPath string, volAccessType model.VolumeAccessType) error {
 	return nil
 }
+
+// MountNFSVolume mounts NFS share onto given target path
+func (driver *FakeDriver) MountNFSVolume(source string, targetPath string, mountOptions []string) error {
+	return nil
+}

--- a/chapi/chapidriver_linux.go
+++ b/chapi/chapidriver_linux.go
@@ -235,6 +235,17 @@ func (driver *LinuxDriver) GetMountsForDevice(device *model.Device) ([]*model.Mo
 	return linux.GetMountPointsForDevices(devices)
 }
 
+func (driver *LinuxDriver) MountNFSVolume(source string, targetPath string, mountOptions []string) error {
+	log.Tracef(">>>>> MountNFSVolume called with source %s target %s options %v: ", source, targetPath, mountOptions)
+	defer log.Trace("<<<<< MountNFSVolume")
+
+	err := linux.MountNFSShare(source, targetPath, mountOptions)
+	if err != nil {
+		return fmt.Errorf("Error mounting nfs share %s at %s, err %s", source, targetPath, err.Error())
+	}
+	return nil
+}
+
 // MountDevice mounts the given device to the given mount point. This must be idempotent.
 func (driver *LinuxDriver) MountDevice(device *model.Device, mountPoint string, mountOptions []string, fsOpts *model.FilesystemOpts) (*model.Mount, error) {
 	log.Tracef(">>>>> MountDevice, device: %+v, mountPoint: %s, mountOptions: %v, fsOpts: %+v", device, mountPoint, mountOptions, fsOpts)


### PR DESCRIPTION
* Problem:
  * need capability in chapi to perform nfs mounts
* Implementation:
  * add endpoint which performs just mount without device checking.
* Testing: tested with nfs volumes using csi driver.
* Review: gcostea, rkumar
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>