### PR TITLE
chapi: provide option to specify nfs version type

### DIFF
--- a/chapi/chapidriver.go
+++ b/chapi/chapidriver.go
@@ -18,7 +18,7 @@ type Driver interface {
 	DeleteDevice(device *model.Device) error
 	OfflineDevice(device *model.Device) error
 	MountDevice(device *model.Device, mountPoint string, mountOptions []string, fsOpts *model.FilesystemOpts) (*model.Mount, error) // Idempotent
-	MountNFSVolume(source string, target string, mountOptions []string) error                                                       // Idempotent
+	MountNFSVolume(source string, target string, mountOptions []string, nfsType string) error                                       // Idempotent
 	BindMount(mountPoint string, newMountPoint string, rbind bool) error                                                            // Idempotent
 	BindUnmount(mountPoint string) error                                                                                            // Idempotent
 	UnmountDevice(device *model.Device, mountPoint string) (*model.Mount, error)                                                    // Idempotent

--- a/chapi/chapidriver_fake.go
+++ b/chapi/chapidriver_fake.go
@@ -156,6 +156,6 @@ func (driver *FakeDriver) ExpandDevice(targetPath string, volAccessType model.Vo
 }
 
 // MountNFSVolume mounts NFS share onto given target path
-func (driver *FakeDriver) MountNFSVolume(source string, targetPath string, mountOptions []string) error {
+func (driver *FakeDriver) MountNFSVolume(source string, targetPath string, mountOptions []string, nfsType string) error {
 	return nil
 }

--- a/chapi/chapidriver_linux.go
+++ b/chapi/chapidriver_linux.go
@@ -235,11 +235,11 @@ func (driver *LinuxDriver) GetMountsForDevice(device *model.Device) ([]*model.Mo
 	return linux.GetMountPointsForDevices(devices)
 }
 
-func (driver *LinuxDriver) MountNFSVolume(source string, targetPath string, mountOptions []string) error {
+func (driver *LinuxDriver) MountNFSVolume(source string, targetPath string, mountOptions []string, nfsType string) error {
 	log.Tracef(">>>>> MountNFSVolume called with source %s target %s options %v: ", source, targetPath, mountOptions)
 	defer log.Trace("<<<<< MountNFSVolume")
 
-	err := linux.MountNFSShare(source, targetPath, mountOptions)
+	err := linux.MountNFSShare(source, targetPath, mountOptions, nfsType)
 	if err != nil {
 		return fmt.Errorf("Error mounting nfs share %s at %s, err %s", source, targetPath, err.Error())
 	}

--- a/linux/mount.go
+++ b/linux/mount.go
@@ -570,11 +570,16 @@ func MountDeviceWithFileSystem(devPath string, mountPoint string, options []stri
 	return mount, nil
 }
 
-func MountNFSShare(source string, targetPath string, options []string) error {
+func MountNFSShare(source string, targetPath string, options []string, nfsType string) error {
 	log.Tracef(">>>>> MountNFSShare called with source %s target %s", source, targetPath)
 	defer log.Tracef("<<<<< MountNFSShare")
 
-	args := []string{source, targetPath}
+	// default nfs version to 4.0
+	if nfsType == "" {
+		nfsType = "nfs4"
+	}
+
+	args := []string{fmt.Sprintf("-t %s", nfsType), source, targetPath}
 	optionArgs := []string{}
 	if len(options) != 0 {
 		optionArgs = append([]string{"-o"}, strings.Join(options, ","))

--- a/linux/mount.go
+++ b/linux/mount.go
@@ -75,6 +75,7 @@ const (
 	fsext3command  = "mkfs.ext3"
 	fsext4command  = "mkfs.ext4"
 	fsbtrfscommand = "mkfs.btrfs"
+	defaultNFSType = "nfs4"
 )
 
 // HashMountID : get hash of the string
@@ -571,15 +572,15 @@ func MountDeviceWithFileSystem(devPath string, mountPoint string, options []stri
 }
 
 func MountNFSShare(source string, targetPath string, options []string, nfsType string) error {
-	log.Tracef(">>>>> MountNFSShare called with source %s target %s", source, targetPath)
+	log.Tracef(">>>>> MountNFSShare called with source %s target %s type %s", source, targetPath, nfsType)
 	defer log.Tracef("<<<<< MountNFSShare")
 
-	// default nfs version to 4.0
+	// default type as nfs4
 	if nfsType == "" {
-		nfsType = "nfs4"
+		nfsType = defaultNFSType
 	}
 
-	args := []string{fmt.Sprintf("-t %s", nfsType), source, targetPath}
+	args := []string{fmt.Sprintf("-t%s", nfsType), source, targetPath}
 	optionArgs := []string{}
 	if len(options) != 0 {
 		optionArgs = append([]string{"-o"}, strings.Join(options, ","))


### PR DESCRIPTION
* Problem:
  * Some flavors default to nfs4 and others to nfs4.1 causing mounts to fail if
  * server doesn't support 4.1
* Implementation:
  * Add nfsType option to mount
* Testing: tested with multiple nfs mounts using csi
* Review: gcostea, rkumar, sbyadarahalli
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>