### PR TITLE
logger:  Windows Notepad requires CRLF and not just LF

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Hewlett Packard Enterprise Development LP
+// Copyright 2020 Hewlett Packard Enterprise Development LP
 
 package logger
 
@@ -330,6 +330,17 @@ func (hook *FileHook) Fire(entry *log.Entry) error {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not read log entry. %v", err)
 		return err
+	}
+
+	// For Windows only, insert '/r' in front of any tailing '/n'.  Windows text files end
+	// lines with CRLF while other platforms just end with LF.
+	if runtime.GOOS == "windows" {
+		for i := len(lineBytes) - 1; i > 0; i-- {
+			if (lineBytes[i] != '\n') || (i > 0 && lineBytes[i-1] == '\r') {
+				break
+			}
+			lineBytes = append(lineBytes[:i], append([]byte{'\r'}, lineBytes[i:]...)...)
+		}
 	}
 
 	hook.logWriter.Write(lineBytes)


### PR DESCRIPTION
* Problem:
  * Windows Notepad, prior to Server 2019, does not display log files properly if they only end with LF
  * Notepad is the default .log viewer for Windows
* Implementation:
  * Modified the logger.Fire() routine to add a custom check for Windows only
  * The logrus Format() handler ends the line with just a LF
  * The additional code scans for any trailing LF (excluding trailing CRLF) and replaces it with CRLF
* Testing:
  * Verified log file viewable under windows
* Reviewers:
  * @shivamerla, @raunakkumar 
* Bug: SV-764