### PR TITLE
Accomodate scanning for multiple lun id

### DIFF
--- a/chapi/chapidriver_linux.go
+++ b/chapi/chapidriver_linux.go
@@ -218,8 +218,7 @@ func (driver *LinuxDriver) GetFilesystemFromDevice(device *model.Device) (*model
 func (driver *LinuxDriver) GetMounts(serialNumber string) ([]*model.Mount, error) {
 	log.Trace(">>>>> GetMounts, serialNumber: ", serialNumber)
 	defer log.Trace("<<<<< GetMounts")
-
-	devices, err := linux.GetLinuxDmDevices(false, serialNumber, "")
+	devices, err := linux.GetLinuxDmDevices(false, util.GetVolumeObject(serialNumber, ""))
 	if err != nil {
 		return nil, err
 	}

--- a/chapi/handler_linux.go
+++ b/chapi/handler_linux.go
@@ -16,6 +16,7 @@ import (
 	log "github.com/hpe-storage/common-host-libs/logger"
 	"github.com/hpe-storage/common-host-libs/model"
 	"github.com/hpe-storage/common-host-libs/tunelinux"
+	"github.com/hpe-storage/common-host-libs/util"
 )
 
 var (
@@ -137,7 +138,8 @@ func getChapInfo(w http.ResponseWriter, r *http.Request) {
 //@Router /hosts/{id}/devices [get]
 func getDevices(w http.ResponseWriter, r *http.Request) {
 	function := func() (interface{}, error) {
-		return linux.GetLinuxDmDevices(false, "", "")
+
+		return linux.GetLinuxDmDevices(false, util.GetVolumeObject("", ""))
 	}
 	handleRequest(function, "getDevices", w, r)
 }
@@ -280,7 +282,7 @@ func getDeviceForSerialNumber(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	devices, err := linux.GetLinuxDmDevices(false, serialnumber, "")
+	devices, err := linux.GetLinuxDmDevices(false, util.GetVolumeObject(serialnumber, ""))
 	if err != nil {
 		handleError(w, chapiResp, err, http.StatusInternalServerError)
 		return
@@ -317,7 +319,7 @@ func getPartitionsForDevice(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	devices, err := linux.GetLinuxDmDevices(false, serialnumber, "")
+	devices, err := linux.GetLinuxDmDevices(false, util.GetVolumeObject(serialnumber, ""))
 	if err != nil {
 		handleError(w, chapiResp, err, http.StatusInternalServerError)
 		return
@@ -395,7 +397,7 @@ func getMountForDevice(w http.ResponseWriter, r *http.Request) {
 	mountid := vars["mountid"]
 	serialNumber := vars["serialNumber"]
 
-	devices, err := linux.GetLinuxDmDevices(false, serialNumber, "")
+	devices, err := linux.GetLinuxDmDevices(false, util.GetVolumeObject(serialNumber, ""))
 	if err != nil {
 		handleError(w, chapiResp, err, http.StatusInternalServerError)
 		return

--- a/linux/device.go
+++ b/linux/device.go
@@ -394,10 +394,12 @@ func rescanLoginVolume(volume *model.Volume) error {
 		if err != nil {
 			return err
 		}
-		if len(volume.SecondaryLunIDs) > 0 {
+		lunIdArray := util.GetSecondaryArrayLUNIds(volume.SecondaryArrayDetails)
+
+		if len(lunIdArray) > 0 {
 			// There are secondary LUN's to scan on FC
-			for _, lun_id := range strings.Split(volume.SecondaryLunIDs, ",") {
-				err = RescanFcTarget(lun_id)
+			for _, lun_id := range lunIdArray {
+				err = RescanFcTarget(strconv.Itoa(int(lun_id)))
 				if err != nil {
 					return err
 				}
@@ -563,9 +565,10 @@ func handleOrphanPaths(volume *model.Volume) error {
 	if err != nil {
 		return err
 	}
-	if len(volume.SecondaryLunIDs) > 0 {
-		for _, lunID := range strings.Split(volume.SecondaryLunIDs, ",") {
-			err := handleOrphanPathsForSpecificLunId(lunID)
+	lunIdArray := util.GetSecondaryArrayLUNIds(volume.SecondaryArrayDetails)
+	if len(lunIdArray) > 0 {
+		for _, lunID := range lunIdArray {
+			err := handleOrphanPathsForSpecificLunId(strconv.Itoa(int(lunID)))
 			if err != nil {
 				return err
 			}
@@ -622,9 +625,10 @@ func handleRemappedLun(volume *model.Volume) (err error) {
 	if err != nil {
 		return err
 	}
-	if len(volume.SecondaryLunIDs) > 0 {
-		for _, lunID = range strings.Split(volume.SecondaryLunIDs, ",") {
-			err = handleRemapForSpecificLunID(volume.SerialNumber, "0"+lunID, volume.AccessProtocol)
+	lunIdArray := util.GetSecondaryArrayLUNIds(volume.SecondaryArrayDetails)
+	if len(lunIdArray) > 0 {
+		for _, secLunID := range lunIdArray {
+			err = handleRemapForSpecificLunID(volume.SerialNumber, "0"+strconv.Itoa(int(secLunID)), volume.AccessProtocol)
 			if err != nil {
 				return err
 			}

--- a/linux/device.go
+++ b/linux/device.go
@@ -267,7 +267,7 @@ func GetLinuxDmDevices(needActivePath bool, vol *model.Volume) (a []*model.Devic
 						// handle lunID conflict when lunID is passed
 						if vol.LunID != "" && hcils[3] != vol.LunID &&
 							// lun id passed is not part of peer lun ids in case of peer persistence
-							!isLunIdPresentIn(hcils[3], vol.SecondaryLunIDs) {
+							!isLunIdPresentIn(hcils[3], util.GetSecondaryArrayLUNIds(vol.SecondaryArrayDetails)) {
 							device.State = model.LunIDConflict.String()
 							// delete the path which have a mismatch and continue with other paths
 							log.Warnf("device with serial %s has path with lunId %s instead of %s. Deleting path %s.", vol.SerialNumber, strings.Split(path.Hcil, ":")[3], vol.LunID, path.Hcil)
@@ -328,9 +328,9 @@ func GetLinuxDmDevices(needActivePath bool, vol *model.Volume) (a []*model.Devic
 	}
 	return devices, nil
 }
-func isLunIdPresentIn(searchLun string, luns string) bool {
-	for _, lun_id := range strings.Split(luns, ",") {
-		if searchLun == lun_id {
+func isLunIdPresentIn(searchLun string, luns []int32) bool {
+	for _, lun_id := range luns{
+		if searchLun == strconv.Itoa(int(lun_id)) {
 			return true
 		}
 	}

--- a/linux/device.go
+++ b/linux/device.go
@@ -265,7 +265,7 @@ func GetLinuxDmDevices(needActivePath bool, serialNumber, lunID string) (a []*mo
 						// add all unique lun
 						lunIDSet[hcils[3]] = true
 						// handle lunID conflict when lunID is passed
-						if lunID != "" && hcils[3] != lunID {
+						if lunID != "" && !isLunIdPresentIn(hcils[3], lunID) {
 							device.State = model.LunIDConflict.String()
 							// delete the path which have a mismatch and continue with other paths
 							log.Warnf("device with serial %s has path with lunId %s instead of %s. Deleting path %s.", serialNumber, strings.Split(path.Hcil, ":")[3], lunID, path.Hcil)
@@ -325,6 +325,14 @@ func GetLinuxDmDevices(needActivePath bool, serialNumber, lunID string) (a []*mo
 		}
 	}
 	return devices, nil
+}
+func isLunIdPresentIn(searchLun string, luns string) bool {
+	for _, lun_id := range strings.Split(luns, ",") {
+		if searchLun == lun_id {
+			return true
+		}
+	}
+	return false
 }
 
 func getSizeOfDeviceInMiB(minorDev string, device *model.Device) (int64, error) {

--- a/linux/device.go
+++ b/linux/device.go
@@ -267,7 +267,7 @@ func GetLinuxDmDevices(needActivePath bool, vol *model.Volume) (a []*model.Devic
 						// handle lunID conflict when lunID is passed
 						if vol.LunID != "" && hcils[3] != vol.LunID &&
 							// lun id passed is not part of peer lun ids in case of peer persistence
-							!isLunIdPresentIn(hcils[3], vol.PeerLunIDs) {
+							!isLunIdPresentIn(hcils[3], vol.SecondaryLunIDs) {
 							device.State = model.LunIDConflict.String()
 							// delete the path which have a mismatch and continue with other paths
 							log.Warnf("device with serial %s has path with lunId %s instead of %s. Deleting path %s.", vol.SerialNumber, strings.Split(path.Hcil, ":")[3], vol.LunID, path.Hcil)
@@ -394,9 +394,9 @@ func rescanLoginVolume(volume *model.Volume) error {
 		if err != nil {
 			return err
 		}
-		if len(volume.PeerLunIDs) > 0 {
+		if len(volume.SecondaryLunIDs) > 0 {
 			// There are secondary LUN's to scan on FC
-			for _, lun_id := range strings.Split(volume.PeerLunIDs, ",") {
+			for _, lun_id := range strings.Split(volume.SecondaryLunIDs, ",") {
 				err = RescanFcTarget(lun_id)
 				if err != nil {
 					return err
@@ -563,8 +563,8 @@ func handleOrphanPaths(volume *model.Volume) error {
 	if err != nil {
 		return err
 	}
-	if len(volume.PeerLunIDs) > 0 {
-		for _, lunID := range strings.Split(volume.PeerLunIDs, ",") {
+	if len(volume.SecondaryLunIDs) > 0 {
+		for _, lunID := range strings.Split(volume.SecondaryLunIDs, ",") {
 			err := handleOrphanPathsForSpecificLunId(lunID)
 			if err != nil {
 				return err
@@ -622,8 +622,8 @@ func handleRemappedLun(volume *model.Volume) (err error) {
 	if err != nil {
 		return err
 	}
-	if len(volume.PeerLunIDs) > 0 {
-		for _, lunID = range strings.Split(volume.PeerLunIDs, ",") {
+	if len(volume.SecondaryLunIDs) > 0 {
+		for _, lunID = range strings.Split(volume.SecondaryLunIDs, ",") {
 			err = handleRemapForSpecificLunID(volume.SerialNumber, "0"+lunID, volume.AccessProtocol)
 			if err != nil {
 				return err

--- a/linux/fc.go
+++ b/linux/fc.go
@@ -119,9 +119,11 @@ func RescanFcTarget(lunID string) (err error) {
 				log.Debugf("error writing to file %s : %s", fcHostScanPath, err.Error())
 			}
 		} else {
-			err = ioutil.WriteFile(fcHostScanPath, []byte("- - "+lunID), 0644)
-			if err != nil {
-				log.Debugf("error writing to file %s : %s", fcHostScanPath, err.Error())
+			for _, lun_id := range strings.Split(lunID, ",") {
+				err = ioutil.WriteFile(fcHostScanPath, []byte("- - "+lun_id), 0644)
+				if err != nil {
+					log.Debugf("error writing to file %s : %s", fcHostScanPath, err.Error())
+				}
 			}
 		}
 		if err != nil {

--- a/linux/fc.go
+++ b/linux/fc.go
@@ -119,11 +119,10 @@ func RescanFcTarget(lunID string) (err error) {
 				log.Debugf("error writing to file %s : %s", fcHostScanPath, err.Error())
 			}
 		} else {
-			for _, lun_id := range strings.Split(lunID, ",") {
-				err = ioutil.WriteFile(fcHostScanPath, []byte("- - "+lun_id), 0644)
-				if err != nil {
-					log.Debugf("error writing to file %s : %s", fcHostScanPath, err.Error())
-				}
+			log.Tracef("\n SCANNING fc lun id %s", lunID)
+			err = ioutil.WriteFile(fcHostScanPath, []byte("- - "+lunID), 0644)
+			if err != nil {
+				log.Debugf("error writing to file %s : %s", fcHostScanPath, err.Error())
 			}
 		}
 		if err != nil {

--- a/linux/iscsi.go
+++ b/linux/iscsi.go
@@ -197,11 +197,13 @@ func HandleIscsiDiscovery(volume *model.Volume) (err error) {
 
 	// determine if all required targets are already logged-in
 	var combinedTargetsNames []string
-	combinedTargetsNames = append(volume.TargetNames())
+	combinedTargetsNames = volume.TargetNames()
 
 	secondaryTargetList := util.GetSecondaryArrayTargetNames(volume.SecondaryArrayDetails)
 	if len(secondaryTargetList) > 0 {
-		combinedTargetsNames = append(secondaryTargetList)
+		for _, val := range secondaryTargetList {
+			combinedTargetsNames = append(combinedTargetsNames, val)
+		}
 	}
 	log.Tracef("\nCOMBINED target names %v", combinedTargetsNames)
 

--- a/linux/iscsi.go
+++ b/linux/iscsi.go
@@ -208,6 +208,16 @@ func HandleIscsiDiscovery(volume *model.Volume) (err error) {
 		log.Errorf("Unable to rescan iscsi hosts, Error: %s", err.Error())
 		return fmt.Errorf("Unable to rescan iscsi hosts, Error: %s", err.Error())
 	}
+	if len(volume.PeerLunIDs) > 0 {
+		// There are secondary LUN's to scan on FC
+		for _, lun_id := range strings.Split(volume.PeerLunIDs, ",") {
+			err = RescanIscsi(lun_id)
+			if err != nil {
+				log.Errorf("Unable to rescan iscsi hosts, Error: %s", err.Error())
+				return fmt.Errorf("Unable to rescan iscsi hosts, Error: %s", err.Error())
+			}
+		}
+	}
 	return nil
 }
 

--- a/linux/iscsi.go
+++ b/linux/iscsi.go
@@ -898,10 +898,14 @@ func rescanIscsiHosts(iscsiHosts []string, lunID string) (err error) {
 					log.Tracef("error writing to file %s : %s", iscsiHostScanPath, err.Error())
 				}
 			} else {
-				err = ioutil.WriteFile(iscsiHostScanPath, []byte("- - "+lunID), 0644)
-				if err != nil {
-					log.Tracef("error writing to file %s : %s", iscsiHostScanPath, err.Error())
+				for _, lun_id := range strings.Split(lunID, ",") {
+					log.Printf("\n SCANNING lun id %v", lun_id)
+					err = ioutil.WriteFile(iscsiHostScanPath, []byte("- - "+lun_id), 0644)
+					if err != nil {
+						log.Tracef("error writing to file %s : %s", iscsiHostScanPath, err.Error())
+					}
 				}
+
 			}
 			if err != nil {
 				log.Errorf("unable to rescan for scsi devices on host %s err %s", iscsiHost, err.Error())
@@ -985,4 +989,3 @@ func bindIface(network model.NetworkInterface) error {
 	}
 	return nil
 }
-

--- a/linux/iscsi.go
+++ b/linux/iscsi.go
@@ -151,7 +151,7 @@ func loginToVolume(volume *model.Volume) (err error) {
 	}
 	secondaryTargetList := util.GetSecondaryArrayTargetNames(volume.SecondaryArrayDetails)
 	secondaryTargetDiscoveryIps := util.GetSecondaryArrayDiscoveryIps(volume.SecondaryArrayDetails)
-	if len(secondaryTargetList) > 1 {
+	if len(secondaryTargetList) > 0 {
 		// if multiple targets for single volume, then fetch all reachable discovery portals
 		reachablePortals, _ = getReachableDiscoveryPortals(secondaryTargetDiscoveryIps, false)
 	} else {

--- a/linux/iscsi.go
+++ b/linux/iscsi.go
@@ -150,11 +150,12 @@ func loginToVolume(volume *model.Volume) (err error) {
 		reachablePortals, _ = getReachableDiscoveryPortals(volume.DiscoveryIPs, true)
 	}
 	secondaryTargetList := util.GetSecondaryArrayTargetNames(volume.SecondaryArrayDetails)
+	secondaryTargetDiscoveryIps := util.GetSecondaryArrayDiscoveryIps(volume.SecondaryArrayDetails)
 	if len(secondaryTargetList) > 1 {
 		// if multiple targets for single volume, then fetch all reachable discovery portals
-		reachablePortals, _ = getReachableDiscoveryPortals(secondaryTargetList, false)
+		reachablePortals, _ = getReachableDiscoveryPortals(secondaryTargetDiscoveryIps, false)
 	} else {
-		reachablePortals, _ = getReachableDiscoveryPortals(secondaryTargetList, true)
+		reachablePortals, _ = getReachableDiscoveryPortals(secondaryTargetDiscoveryIps, true)
 	}
 	if len(reachablePortals) == 0 {
 		return fmt.Errorf("none of the discovery portals provided [%+v] are reachable", volume.DiscoveryIPs)

--- a/linux/iscsi.go
+++ b/linux/iscsi.go
@@ -175,7 +175,17 @@ func loginToVolume(volume *model.Volume) (err error) {
 	}
 
 	// login to all targets for given volume
-	for _, target := range volume.TargetNames() {
+
+        var combinedTargetsNames []string
+        combinedTargetsNames = volume.TargetNames()
+
+        if len(secondaryTargetList) > 0 {
+                for _, val := range secondaryTargetList {
+                        combinedTargetsNames = append(combinedTargetsNames, val)
+                }
+        }
+        log.Tracef("\nCOMBINED target names %v", combinedTargetsNames)
+	for _, target := range combinedTargetsNames {
 		if volume.Chap == nil {
 			err = loginToTarget(discoveredTargets, target, ifaces, "", "", volume.ConnectionMode)
 		} else {

--- a/linux/mount.go
+++ b/linux/mount.go
@@ -212,7 +212,7 @@ func CreateFileSystemOnDevice(serialnumber string, fileSystemType string) (dev *
 	log.Tracef("CreateFileSystemOnDevice called with :%s %s", serialnumber, fileSystemType)
 	var devices []*model.Device
 	for i := 1; i <= countdownTicker; i++ {
-		devices, err = GetLinuxDmDevices(true, serialnumber, "")
+		devices, err = GetLinuxDmDevices(true, util.GetVolumeObject(serialnumber, ""))
 		if err != nil {
 			log.Debugf("error to retrieve active paths for %s, retrying, count=%d", serialnumber, i)
 			continue

--- a/model/types.go
+++ b/model/types.go
@@ -166,36 +166,37 @@ type DevicePartition struct {
 
 // Volume : Thin version of Volume object for Host side
 type Volume struct {
-	ID                   string                 `json:"id,omitempty"`
-	Name                 string                 `json:"name,omitempty"`
-	Size                 int64                  `json:"size,omitempty"` // size in bytes
-	Description          string                 `json:"description,omitempty"`
-	InUse                bool                   `json:"in_use,omitempty"` // deprecated for published in the CSP implementation
-	Published            bool                   `json:"published,omitempty"`
-	BaseSnapID           string                 `json:"base_snapshot_id,omitempty"`
-	ParentVolID          string                 `json:"parent_volume_id,omitempty"`
-	Clone                bool                   `json:"clone,omitempty"`
-	Config               map[string]interface{} `json:"config,omitempty"`
-	Metadata             []*KeyValue            `json:"metadata,omitempty"`
-	SerialNumber         string                 `json:"serial_number,omitempty"`
-	AccessProtocol       string                 `json:"access_protocol,omitempty"`
-	Iqn                  string                 `json:"iqn,omitempty"` // deprecated
-	Iqns                 []string               `json:"iqns,omitempty"`
-	DiscoveryIP          string                 `json:"discovery_ip,omitempty"` // deprecated
-	DiscoveryIPs         []string               `json:"discovery_ips,omitempty"`
-	MountPoint           string                 `json:"Mountpoint,omitempty"`
-	Status               map[string]interface{} `json:"status,omitempty"` // interface so that we can map any number of arguments
-	Chap                 *ChapInfo              `json:"chap_info,omitempty"`
-	Networks             []*NetworkInterface    `json:"networks,omitempty"`
-	ConnectionMode       string                 `json:"connection_mode,omitempty"`
-	LunID                string                 `json:"lun_id,omitempty"`
-	SecondaryLunIDs      string                 `json:"secondary_lun_ids,omitempty"`
-	SecondaryTargetNames string                 `json:"secondary_target_names,omitempty"`
-	SecondaryDiscoverIps string                 `json:"secondary_discovery_ips,omitempty"`
-	TargetScope          string                 `json:"target_scope,omitempty"` //GST="group", VST="volume" or empty(older array fiji etc), and no-op for FC
-	IscsiSessions        []*IscsiSession        `json:"iscsi_sessions,omitempty"`
-	FcSessions           []*FcSession           `json:"fc_sessions,omitempty"`
-	VolumeGroupId        string                 `json:"volume_group_id"`
+	ID                    string                 `json:"id,omitempty"`
+	Name                  string                 `json:"name,omitempty"`
+	Size                  int64                  `json:"size,omitempty"` // size in bytes
+	Description           string                 `json:"description,omitempty"`
+	InUse                 bool                   `json:"in_use,omitempty"` // deprecated for published in the CSP implementation
+	Published             bool                   `json:"published,omitempty"`
+	BaseSnapID            string                 `json:"base_snapshot_id,omitempty"`
+	ParentVolID           string                 `json:"parent_volume_id,omitempty"`
+	Clone                 bool                   `json:"clone,omitempty"`
+	Config                map[string]interface{} `json:"config,omitempty"`
+	Metadata              []*KeyValue            `json:"metadata,omitempty"`
+	SerialNumber          string                 `json:"serial_number,omitempty"`
+	AccessProtocol        string                 `json:"access_protocol,omitempty"`
+	Iqn                   string                 `json:"iqn,omitempty"` // deprecated
+	Iqns                  []string               `json:"iqns,omitempty"`
+	DiscoveryIP           string                 `json:"discovery_ip,omitempty"` // deprecated
+	DiscoveryIPs          []string               `json:"discovery_ips,omitempty"`
+	MountPoint            string                 `json:"Mountpoint,omitempty"`
+	Status                map[string]interface{} `json:"status,omitempty"` // interface so that we can map any number of arguments
+	Chap                  *ChapInfo              `json:"chap_info,omitempty"`
+	Networks              []*NetworkInterface    `json:"networks,omitempty"`
+	ConnectionMode        string                 `json:"connection_mode,omitempty"`
+	LunID                 string                 `json:"lun_id,omitempty"`
+	SecondaryLunIDs       string                 `json:"secondary_lun_ids,omitempty"`
+	SecondaryTargetNames  string                 `json:"secondary_target_names,omitempty"`
+	SecondaryDiscoverIps  string                 `json:"secondary_discovery_ips,omitempty"`
+	TargetScope           string                 `json:"target_scope,omitempty"` //GST="group", VST="volume" or empty(older array fiji etc), and no-op for FC
+	IscsiSessions         []*IscsiSession        `json:"iscsi_sessions,omitempty"`
+	FcSessions            []*FcSession           `json:"fc_sessions,omitempty"`
+	VolumeGroupId         string                 `json:"volume_group_id"`
+	SecondaryArrayDetails string                 `json:"secondary_array_details"`
 }
 
 func (v Volume) TargetNames() []string {

--- a/model/types.go
+++ b/model/types.go
@@ -193,7 +193,7 @@ type Volume struct {
 	IscsiSessions         []*IscsiSession        `json:"iscsi_sessions,omitempty"`
 	FcSessions            []*FcSession           `json:"fc_sessions,omitempty"`
 	VolumeGroupId         string                 `json:"volume_group_id"`
-	SecondaryArrayDetails string                 `json:"secondary_array_details"`
+	SecondaryArrayDetails string                 `json:"secondary_array_details,omitempty"`
 }
 
 func (v Volume) TargetNames() []string {

--- a/model/types.go
+++ b/model/types.go
@@ -292,7 +292,7 @@ type BlockDeviceAccessInfo struct {
 
 // Information of LUN id, IQN, discovery IP's the secondary array
 type SecondaryBackendDetails struct {
-	PeerArrayDetails []SecondaryLunInfo
+	PeerArrayDetails []*SecondaryLunInfo
 }
 
 // Information of the each secondary array

--- a/model/types.go
+++ b/model/types.go
@@ -284,7 +284,7 @@ type AccessInfo struct {
 type BlockDeviceAccessInfo struct {
 	AccessProtocol string   `json:"access_protocol,omitempty"`
 	TargetNames    []string `json:"target_names,omitempty"`
-	LunID          string   `json:"lun_id,omitempty"`
+	LunID          []int32  `json:"lun_id,omitempty"`
 	IscsiAccessInfo
 }
 

--- a/model/types.go
+++ b/model/types.go
@@ -189,6 +189,7 @@ type Volume struct {
 	Networks       []*NetworkInterface    `json:"networks,omitempty"`
 	ConnectionMode string                 `json:"connection_mode,omitempty"`
 	LunID          string                 `json:"lun_id,omitempty"`
+	PeerLunIDs     string                 `json:"peer_lun_ids,omitempty"`
 	TargetScope    string                 `json:"target_scope,omitempty"` //GST="group", VST="volume" or empty(older array fiji etc), and no-op for FC
 	IscsiSessions  []*IscsiSession        `json:"iscsi_sessions,omitempty"`
 	FcSessions     []*FcSession           `json:"fc_sessions,omitempty"`
@@ -284,7 +285,8 @@ type AccessInfo struct {
 type BlockDeviceAccessInfo struct {
 	AccessProtocol string   `json:"access_protocol,omitempty"`
 	TargetNames    []string `json:"target_names,omitempty"`
-	LunID          []int32  `json:"lun_id,omitempty"`
+	LunID          int32    `json:"lun_id,omitempty"`
+	PeerLunIDs     []int32  `json:"peer_lun_ids,omitempty"`
 	IscsiAccessInfo
 }
 

--- a/model/types.go
+++ b/model/types.go
@@ -189,9 +189,6 @@ type Volume struct {
 	Networks              []*NetworkInterface    `json:"networks,omitempty"`
 	ConnectionMode        string                 `json:"connection_mode,omitempty"`
 	LunID                 string                 `json:"lun_id,omitempty"`
-	SecondaryLunIDs       string                 `json:"secondary_lun_ids,omitempty"`
-	SecondaryTargetNames  string                 `json:"secondary_target_names,omitempty"`
-	SecondaryDiscoverIps  string                 `json:"secondary_discovery_ips,omitempty"`
 	TargetScope           string                 `json:"target_scope,omitempty"` //GST="group", VST="volume" or empty(older array fiji etc), and no-op for FC
 	IscsiSessions         []*IscsiSession        `json:"iscsi_sessions,omitempty"`
 	FcSessions            []*FcSession           `json:"fc_sessions,omitempty"`

--- a/model/types.go
+++ b/model/types.go
@@ -284,7 +284,7 @@ type AccessInfo struct {
 type BlockDeviceAccessInfo struct {
 	AccessProtocol string   `json:"access_protocol,omitempty"`
 	TargetNames    []string `json:"target_names,omitempty"`
-	LunID          int32    `json:"lun_id,omitempty"`
+	LunID          string   `json:"lun_id,omitempty"`
 	IscsiAccessInfo
 }
 

--- a/model/types.go
+++ b/model/types.go
@@ -166,34 +166,36 @@ type DevicePartition struct {
 
 // Volume : Thin version of Volume object for Host side
 type Volume struct {
-	ID             string                 `json:"id,omitempty"`
-	Name           string                 `json:"name,omitempty"`
-	Size           int64                  `json:"size,omitempty"` // size in bytes
-	Description    string                 `json:"description,omitempty"`
-	InUse          bool                   `json:"in_use,omitempty"` // deprecated for published in the CSP implementation
-	Published      bool                   `json:"published,omitempty"`
-	BaseSnapID     string                 `json:"base_snapshot_id,omitempty"`
-	ParentVolID    string                 `json:"parent_volume_id,omitempty"`
-	Clone          bool                   `json:"clone,omitempty"`
-	Config         map[string]interface{} `json:"config,omitempty"`
-	Metadata       []*KeyValue            `json:"metadata,omitempty"`
-	SerialNumber   string                 `json:"serial_number,omitempty"`
-	AccessProtocol string                 `json:"access_protocol,omitempty"`
-	Iqn            string                 `json:"iqn,omitempty"` // deprecated
-	Iqns           []string               `json:"iqns,omitempty"`
-	DiscoveryIP    string                 `json:"discovery_ip,omitempty"` // deprecated
-	DiscoveryIPs   []string               `json:"discovery_ips,omitempty"`
-	MountPoint     string                 `json:"Mountpoint,omitempty"`
-	Status         map[string]interface{} `json:"status,omitempty"` // interface so that we can map any number of arguments
-	Chap           *ChapInfo              `json:"chap_info,omitempty"`
-	Networks       []*NetworkInterface    `json:"networks,omitempty"`
-	ConnectionMode string                 `json:"connection_mode,omitempty"`
-	LunID          string                 `json:"lun_id,omitempty"`
-	PeerLunIDs     string                 `json:"peer_lun_ids,omitempty"`
-	TargetScope    string                 `json:"target_scope,omitempty"` //GST="group", VST="volume" or empty(older array fiji etc), and no-op for FC
-	IscsiSessions  []*IscsiSession        `json:"iscsi_sessions,omitempty"`
-	FcSessions     []*FcSession           `json:"fc_sessions,omitempty"`
-	VolumeGroupId  string                 `json:"volume_group_id"`
+	ID                   string                 `json:"id,omitempty"`
+	Name                 string                 `json:"name,omitempty"`
+	Size                 int64                  `json:"size,omitempty"` // size in bytes
+	Description          string                 `json:"description,omitempty"`
+	InUse                bool                   `json:"in_use,omitempty"` // deprecated for published in the CSP implementation
+	Published            bool                   `json:"published,omitempty"`
+	BaseSnapID           string                 `json:"base_snapshot_id,omitempty"`
+	ParentVolID          string                 `json:"parent_volume_id,omitempty"`
+	Clone                bool                   `json:"clone,omitempty"`
+	Config               map[string]interface{} `json:"config,omitempty"`
+	Metadata             []*KeyValue            `json:"metadata,omitempty"`
+	SerialNumber         string                 `json:"serial_number,omitempty"`
+	AccessProtocol       string                 `json:"access_protocol,omitempty"`
+	Iqn                  string                 `json:"iqn,omitempty"` // deprecated
+	Iqns                 []string               `json:"iqns,omitempty"`
+	DiscoveryIP          string                 `json:"discovery_ip,omitempty"` // deprecated
+	DiscoveryIPs         []string               `json:"discovery_ips,omitempty"`
+	MountPoint           string                 `json:"Mountpoint,omitempty"`
+	Status               map[string]interface{} `json:"status,omitempty"` // interface so that we can map any number of arguments
+	Chap                 *ChapInfo              `json:"chap_info,omitempty"`
+	Networks             []*NetworkInterface    `json:"networks,omitempty"`
+	ConnectionMode       string                 `json:"connection_mode,omitempty"`
+	LunID                string                 `json:"lun_id,omitempty"`
+	SecondaryLunIDs      string                 `json:"secondary_lun_ids,omitempty"`
+	SecondaryTargetNames string                 `json:"secondary_target_names,omitempty"`
+	SecondaryDiscoverIps string                 `json:"secondary_discovery_ips,omitempty"`
+	TargetScope          string                 `json:"target_scope,omitempty"` //GST="group", VST="volume" or empty(older array fiji etc), and no-op for FC
+	IscsiSessions        []*IscsiSession        `json:"iscsi_sessions,omitempty"`
+	FcSessions           []*FcSession           `json:"fc_sessions,omitempty"`
+	VolumeGroupId        string                 `json:"volume_group_id"`
 }
 
 func (v Volume) TargetNames() []string {
@@ -286,7 +288,19 @@ type BlockDeviceAccessInfo struct {
 	AccessProtocol string   `json:"access_protocol,omitempty"`
 	TargetNames    []string `json:"target_names,omitempty"`
 	LunID          int32    `json:"lun_id,omitempty"`
-	PeerLunIDs     []int32  `json:"peer_lun_ids,omitempty"`
+	SecondaryBackendDetails
+	IscsiAccessInfo
+}
+
+// Information of LUN id, IQN, discovery IP's the secondary array
+type SecondaryBackendDetails struct {
+	PeerArrayDetails []SecondaryLunInfo
+}
+
+// Information of the each secondary array
+type SecondaryLunInfo struct {
+	LunID       int32    `json:"lun_id,omitempty""`
+	TargetNames []string `json:"target_names,omitempty"`
 	IscsiAccessInfo
 }
 

--- a/tunelinux/config.go
+++ b/tunelinux/config.go
@@ -266,7 +266,7 @@ func GetRecommendations() (settings []*Recommendation, err error) {
 	var fcRecommendations []*Recommendation
 
 	// Get all nimble devices
-	devices, err := linux.GetLinuxDmDevices(false, "", "")
+	devices, err := linux.GetLinuxDmDevices(false, util.GetVolumeObject("", ""))
 	if err != nil {
 		log.Error("Unable to get Nimble devices ", err.Error())
 		return nil, err

--- a/tunelinux/disk.go
+++ b/tunelinux/disk.go
@@ -132,7 +132,7 @@ func GetDeviceRecommendations(devices []*model.Device) (settings []*Recommendati
 
 func updateUdevRule() (err error) {
 	// Get all nimble devices
-	devices, err := linux.GetLinuxDmDevices(true, "", "")
+	devices, err := linux.GetLinuxDmDevices(true, util.GetVolumeObject("", ""))
 	if err != nil {
 		log.Error("Unable to get Nimble devices ", err.Error())
 		return err

--- a/util/strings.go
+++ b/util/strings.go
@@ -3,6 +3,8 @@
 package util
 
 import (
+	"bytes"
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -29,4 +31,18 @@ func ToCamelCase(str string) string {
 		return ""
 	}
 	return strings.ToLower(camelCase[:1]) + camelCase[1:]
+}
+
+// ConvertArrayOfIntToString converts a given list of integer to comma separated string value
+func ConvertArrayOfIntToString(lun_ids []int32) string {
+	var buffer bytes.Buffer
+
+	for i := 0; i < len(lun_ids); i++ {
+		if i == (len(lun_ids) - 1) {
+			buffer.WriteString(fmt.Sprintf("%d", lun_ids[i]))
+		} else {
+			buffer.WriteString(fmt.Sprintf("%d,", lun_ids[i]))
+		}
+	}
+	return buffer.String()
 }

--- a/util/volume.go
+++ b/util/volume.go
@@ -17,6 +17,7 @@ func GetVolumeObject(serialNumber, lunID string) *model.Volume {
 
 func GetSecondaryArrayLUNIds(details string) []int32 {
 	var secondaryArrayDetails model.SecondaryBackendDetails
+	logger.Tracef("\n About to unmarshal %s", details)
 	err := json.Unmarshal([]byte(details), &secondaryArrayDetails)
 	if err != nil {
 		logger.Tracef("\n Error in GetSecondaryArrayLUNIds %s", err.Error())
@@ -33,6 +34,7 @@ func GetSecondaryArrayLUNIds(details string) []int32 {
 
 func GetSecondaryArrayTargetNames(details string) []string {
 	var secondaryArrayDetails model.SecondaryBackendDetails
+	logger.Tracef("\n About to unmarshal %s", details)
 	err := json.Unmarshal([]byte(details), &secondaryArrayDetails)
 	if err != nil {
 		logger.Tracef("\n Error in GetSecondaryArrayTargetNames %s", err.Error())
@@ -51,6 +53,7 @@ func GetSecondaryArrayTargetNames(details string) []string {
 
 func GetSecondaryArrayDiscoveryIps(details string) []string {
 	var secondaryArrayDetails model.SecondaryBackendDetails
+	logger.Tracef("\n About to unmarshal %s", details)
 	err := json.Unmarshal([]byte(details), &secondaryArrayDetails)
 	if err != nil {
 		logger.Tracef("\n Error in GetSecondaryArrayDiscoveryIps %s", err.Error())

--- a/util/volume.go
+++ b/util/volume.go
@@ -33,7 +33,7 @@ func GetSecondaryArrayTargetNames(details string) []string {
 	var secondaryArrayDetails model.SecondaryBackendDetails
 	err := json.Unmarshal([]byte(details), &secondaryArrayDetails)
 	if err != nil {
-		logger.Tracef("\n Error in GetSecondaryArrayLUNIds %s", err.Error())
+		logger.Tracef("\n Error in GetSecondaryArrayTargetNames %s", err.Error())
 	}
 	numberOfSecondaryBackends := len(secondaryArrayDetails.PeerArrayDetails)
 	var secondaryTargetNames []string
@@ -49,7 +49,7 @@ func GetSecondaryArrayDiscoveryIps(details string) []string {
 	var secondaryArrayDetails model.SecondaryBackendDetails
 	err := json.Unmarshal([]byte(details), &secondaryArrayDetails)
 	if err != nil {
-		logger.Tracef("\n Error in GetSecondaryArrayLUNIds %s", err.Error())
+		logger.Tracef("\n Error in GetSecondaryArrayDiscoveryIps %s", err.Error())
 	}
 	numberOfSecondaryBackends := len(secondaryArrayDetails.PeerArrayDetails)
 	var secondaryDiscoverIps []string

--- a/util/volume.go
+++ b/util/volume.go
@@ -26,7 +26,7 @@ func GetSecondaryArrayLUNIds(details string) []int32 {
 	logger.Tracef("\n About to unmarshal %s", details)
 	err := json.Unmarshal([]byte(details), &secondaryArrayDetails)
 	if err != nil {
-		logger.Tracef("\n Error in GetSecondaryArrayLUNIds %s", err.Error())
+		logger.Errorf("\n Error in GetSecondaryArrayLUNIds %s", err.Error())
 		return []int32{}
 	}
 	numberOfSecondaryBackends := len(secondaryArrayDetails.PeerArrayDetails)
@@ -44,7 +44,7 @@ func GetSecondaryArrayTargetNames(details string) []string {
 	logger.Tracef("\n About to unmarshal %s", details)
 	err := json.Unmarshal([]byte(details), &secondaryArrayDetails)
 	if err != nil {
-		logger.Tracef("\n Error in GetSecondaryArrayTargetNames %s", err.Error())
+		logger.Errorf("\n Error in GetSecondaryArrayTargetNames %s", err.Error())
 		return []string{}
 	}
 	numberOfSecondaryBackends := len(secondaryArrayDetails.PeerArrayDetails)
@@ -64,7 +64,7 @@ func GetSecondaryArrayDiscoveryIps(details string) []string {
 	logger.Tracef("\n About to unmarshal %s", details)
 	err := json.Unmarshal([]byte(details), &secondaryArrayDetails)
 	if err != nil {
-		logger.Tracef("\n Error in GetSecondaryArrayDiscoveryIps %s", err.Error())
+		logger.Errorf("\n Error in GetSecondaryArrayDiscoveryIps %s", err.Error())
 		return []string{}
 	}
 	numberOfSecondaryBackends := len(secondaryArrayDetails.PeerArrayDetails)
@@ -84,8 +84,8 @@ func GetSecondaryBackends(details string) []*model.SecondaryLunInfo {
 	logger.Tracef("\n About to unmarshal %s", details)
 	err := json.Unmarshal([]byte(details), &secondaryArrayDetails)
 	if err != nil {
-		logger.Tracef("\n Error in GetSecondaryBackends %s", err.Error())
-		logger.Tracef("\n Passed details %s", details)
+		logger.Errorf("\n Error in GetSecondaryBackends %s", err.Error())
+		logger.Errorf("\n Passed details %s", details)
 		return nil
 	}
 	return secondaryArrayDetails.PeerArrayDetails

--- a/util/volume.go
+++ b/util/volume.go
@@ -12,6 +12,7 @@ func GetVolumeObject(serialNumber, lunID string) *model.Volume {
 	logger.Tracef(">>>>> GetVolumeObject %s, %s", serialNumber, lunID)
 	defer logger.Tracef("<<<< GetVolumeObject")
 	var volObj *model.Volume
+	volObj = &model.Volume{}
 	volObj.SerialNumber = serialNumber
 	volObj.LunID = lunID
 

--- a/util/volume.go
+++ b/util/volume.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"encoding/json"
+	"github.com/hpe-storage/common-host-libs/logger"
 	"github.com/hpe-storage/common-host-libs/model"
 )
 
@@ -11,4 +13,50 @@ func GetVolumeObject(serialNumber, lunID string) *model.Volume {
 	volObj.LunID = lunID
 
 	return volObj
+}
+
+func GetSecondaryArrayLUNIds(details string) []int32 {
+	var secondaryArrayDetails model.SecondaryBackendDetails
+	err := json.Unmarshal([]byte(details), &secondaryArrayDetails)
+	if err != nil {
+		logger.Tracef("\n Error in GetSecondaryArrayLUNIds %s", err.Error())
+	}
+	numberOfSecondaryBackends := len(secondaryArrayDetails.PeerArrayDetails)
+	var secondaryLunIds []int32 = make([]int32, numberOfSecondaryBackends)
+	for i := 0; i < numberOfSecondaryBackends; i++ {
+		secondaryLunIds[i] = secondaryArrayDetails.PeerArrayDetails[i].LunID
+	}
+	return secondaryLunIds
+}
+
+func GetSecondaryArrayTargetNames(details string) []string {
+	var secondaryArrayDetails model.SecondaryBackendDetails
+	err := json.Unmarshal([]byte(details), &secondaryArrayDetails)
+	if err != nil {
+		logger.Tracef("\n Error in GetSecondaryArrayLUNIds %s", err.Error())
+	}
+	numberOfSecondaryBackends := len(secondaryArrayDetails.PeerArrayDetails)
+	var secondaryTargetNames []string
+	for i := 0; i < numberOfSecondaryBackends; i++ {
+		for _, targetNameRetrieved := range secondaryArrayDetails.PeerArrayDetails[i].TargetNames {
+			secondaryTargetNames = append(secondaryTargetNames, targetNameRetrieved)
+		}
+	}
+	return secondaryTargetNames
+}
+
+func GetSecondaryArrayDiscoveryIps(details string) []string {
+	var secondaryArrayDetails model.SecondaryBackendDetails
+	err := json.Unmarshal([]byte(details), &secondaryArrayDetails)
+	if err != nil {
+		logger.Tracef("\n Error in GetSecondaryArrayLUNIds %s", err.Error())
+	}
+	numberOfSecondaryBackends := len(secondaryArrayDetails.PeerArrayDetails)
+	var secondaryDiscoverIps []string
+	for i := 0; i < numberOfSecondaryBackends; i++ {
+		for _, discoveryIpRetrieved := range secondaryArrayDetails.PeerArrayDetails[i].DiscoveryIPs {
+			secondaryDiscoverIps = append(secondaryDiscoverIps, discoveryIpRetrieved)
+		}
+	}
+	return secondaryDiscoverIps
 }

--- a/util/volume.go
+++ b/util/volume.go
@@ -1,3 +1,5 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
 package util
 
 import (
@@ -7,7 +9,8 @@ import (
 )
 
 func GetVolumeObject(serialNumber, lunID string) *model.Volume {
-
+	logger.Tracef(">>>>> GetVolumeObject %s, %s", serialNumber, lunID)
+	defer logger.Tracef("<<<< GetVolumeObject")
 	var volObj *model.Volume
 	volObj.SerialNumber = serialNumber
 	volObj.LunID = lunID
@@ -16,12 +19,13 @@ func GetVolumeObject(serialNumber, lunID string) *model.Volume {
 }
 
 func GetSecondaryArrayLUNIds(details string) []int32 {
+	logger.Tracef(">>>>> GetSecondaryArrayLUNIds %s", details)
+	defer logger.Tracef("<<<< GetSecondaryArrayLUNIds")
 	var secondaryArrayDetails model.SecondaryBackendDetails
 	logger.Tracef("\n About to unmarshal %s", details)
 	err := json.Unmarshal([]byte(details), &secondaryArrayDetails)
 	if err != nil {
 		logger.Tracef("\n Error in GetSecondaryArrayLUNIds %s", err.Error())
-		logger.Tracef("\n Passed string: %s", details)
 		return []int32{}
 	}
 	numberOfSecondaryBackends := len(secondaryArrayDetails.PeerArrayDetails)
@@ -33,12 +37,13 @@ func GetSecondaryArrayLUNIds(details string) []int32 {
 }
 
 func GetSecondaryArrayTargetNames(details string) []string {
+	logger.Tracef(">>>>> GetSecondaryArrayTargetNames %s", details)
+	defer logger.Tracef("<<<< GetSecondaryArrayTargetNames")
 	var secondaryArrayDetails model.SecondaryBackendDetails
 	logger.Tracef("\n About to unmarshal %s", details)
 	err := json.Unmarshal([]byte(details), &secondaryArrayDetails)
 	if err != nil {
 		logger.Tracef("\n Error in GetSecondaryArrayTargetNames %s", err.Error())
-		logger.Tracef("\n Passed details %s", details)
 		return []string{}
 	}
 	numberOfSecondaryBackends := len(secondaryArrayDetails.PeerArrayDetails)
@@ -52,12 +57,13 @@ func GetSecondaryArrayTargetNames(details string) []string {
 }
 
 func GetSecondaryArrayDiscoveryIps(details string) []string {
+	logger.Tracef(">>>>> GetSecondaryArrayDiscoveryIps %s", details)
+	defer logger.Tracef("<<<< GetSecondaryArrayDiscoveryIps")
 	var secondaryArrayDetails model.SecondaryBackendDetails
 	logger.Tracef("\n About to unmarshal %s", details)
 	err := json.Unmarshal([]byte(details), &secondaryArrayDetails)
 	if err != nil {
 		logger.Tracef("\n Error in GetSecondaryArrayDiscoveryIps %s", err.Error())
-		logger.Tracef("\n Passed details %s", details)
 		return []string{}
 	}
 	numberOfSecondaryBackends := len(secondaryArrayDetails.PeerArrayDetails)
@@ -68,4 +74,19 @@ func GetSecondaryArrayDiscoveryIps(details string) []string {
 		}
 	}
 	return secondaryDiscoverIps
+}
+
+func GetSecondaryBackends(details string) []*model.SecondaryLunInfo {
+	logger.Tracef(">>>>> GetSecondaryBackends %s", details)
+	defer logger.Tracef("<<<< GetSecondaryBackends")
+	var secondaryArrayDetails model.SecondaryBackendDetails
+	logger.Tracef("\n About to unmarshal %s", details)
+	err := json.Unmarshal([]byte(details), &secondaryArrayDetails)
+	if err != nil {
+		logger.Tracef("\n Error in GetSecondaryBackends %s", err.Error())
+		logger.Tracef("\n Passed details %s", details)
+		return nil
+	}
+	return secondaryArrayDetails.PeerArrayDetails
+
 }

--- a/util/volume.go
+++ b/util/volume.go
@@ -1,0 +1,14 @@
+package util
+
+import (
+	"github.com/hpe-storage/common-host-libs/model"
+)
+
+func GetVolumeObject(serialNumber, lunID string) *model.Volume {
+
+	var volObj *model.Volume
+	volObj.SerialNumber = serialNumber
+	volObj.LunID = lunID
+
+	return volObj
+}

--- a/util/volume.go
+++ b/util/volume.go
@@ -20,6 +20,8 @@ func GetSecondaryArrayLUNIds(details string) []int32 {
 	err := json.Unmarshal([]byte(details), &secondaryArrayDetails)
 	if err != nil {
 		logger.Tracef("\n Error in GetSecondaryArrayLUNIds %s", err.Error())
+		logger.Tracef("\n Passed string: %s", details)
+		return []int32{}
 	}
 	numberOfSecondaryBackends := len(secondaryArrayDetails.PeerArrayDetails)
 	var secondaryLunIds []int32 = make([]int32, numberOfSecondaryBackends)
@@ -34,6 +36,8 @@ func GetSecondaryArrayTargetNames(details string) []string {
 	err := json.Unmarshal([]byte(details), &secondaryArrayDetails)
 	if err != nil {
 		logger.Tracef("\n Error in GetSecondaryArrayTargetNames %s", err.Error())
+		logger.Tracef("\n Passed details %s", details)
+		return []string{}
 	}
 	numberOfSecondaryBackends := len(secondaryArrayDetails.PeerArrayDetails)
 	var secondaryTargetNames []string
@@ -50,6 +54,8 @@ func GetSecondaryArrayDiscoveryIps(details string) []string {
 	err := json.Unmarshal([]byte(details), &secondaryArrayDetails)
 	if err != nil {
 		logger.Tracef("\n Error in GetSecondaryArrayDiscoveryIps %s", err.Error())
+		logger.Tracef("\n Passed details %s", details)
+		return []string{}
 	}
 	numberOfSecondaryBackends := len(secondaryArrayDetails.PeerArrayDetails)
 	var secondaryDiscoverIps []string


### PR DESCRIPTION
- Current in 3PAR/Primera CSP we are adding requirement for Peer persistence based Replication, where we need to create host and vlun's for both the Primary (source) array and the Target (secondary) array, so that the multipath device mapping will have paths from active/passive arrays. But, the publish volume response from CSP to CSI has currently support for only returning a single lun id. The change here is to return a object called SecondaryArrayDetails which will have list of object PeerDetails which has lun id, discovery ip, target names etc. One PeerDetail will be created per secondary backend.


- Approach

Changes are done to find, if the multiple luns are passed based on the number of PeerDetails in SecondaryArrayDetails struct. iscsi login , scanning all takes care of reading this object, and invokes appropriate actions.


Signed-off-by: William Durairaj <w_durairaj@yahoo.com>