### PR TITLE
chapi: remove redundant call to close pinger channel on responses.

### DIFF
--- a/linux/iscsi.go
+++ b/linux/iscsi.go
@@ -339,7 +339,6 @@ func isReachable(initiatorIP, targetIP string) (reachable bool, err error) {
 		log.Tracef("Received %d bytes from %s: icmp_seq=%d time=%v ttl=%v\n",
 			pkt.Nbytes, pkt.Addr, pkt.Seq, pkt.Rtt, pkt.Ttl)
 		reachable = true
-		pinger.Stop()
 	}
 
 	// Perform the ping test; if we received any ICMP packet back, stop the test


### PR DESCRIPTION
* Problem:
  * Run() method of go-ping is closing channel already on completion
  * of 5 ping responses and in cases of timeouts. With additional
  * closure during onRecv() can cause panic if multiple ping requests
  * are inflight.
* Implementation:
  * Remove additional channel closure in client code and let go-ping
  * package handle it.
* Testing: Tested pod attach/detach on multiple nodes.
* Review: gcostea, rkumar
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>