### PR TITLE
common-host-libs: Regex to detect orphan paths using single digit SCSI host number in H:C:T:L format

### DIFF
--- a/linux/multipath.go
+++ b/linux/multipath.go
@@ -27,7 +27,7 @@ const (
 	MultipathConf = "/etc/multipath.conf"
 	// MultipathBindings bindings file for multipathd
 	MultipathBindings  = "/etc/multipath/bindings"
-	orphanPathsPattern = ".*(?P<host>\\d+):(?P<channel>\\d+):(?P<target>\\d+):(?P<lun>\\d+).*(REPLACE_VENDOR).*orphan"
+	orphanPathsPattern = ".*\\s+(?P<host>\\d+):(?P<channel>\\d+):(?P<target>\\d+):(?P<lun>\\d+).*(REPLACE_VENDOR).*orphan"
 	maxTries           = 3
 )
 


### PR DESCRIPTION


* Problem:
  * Due to current regex, only devices with single digit host numbers in (H:C:T:L) are
  * filtered to detect orphan paths. This is causing delay in device attach when
  * paths are kept in orphan state by multipathd.
* Implementation:
  * Fix the regex to consider space before H:C:T:L numbers, so SCSI host numbers like
  * 10, 11 etc are detected as well.
* Testing: Tested on scale setup to ensure orphan paths are detected correctly to speed up discovery.
* Review: gcostea, sbyadarahalli, rkumar
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>