### PR TITLE
Modified files for handling multiple iscsi session logout

### DIFF
--- a/linux/device.go
+++ b/linux/device.go
@@ -244,8 +244,13 @@ func GetLinuxDmDevices(needActivePath bool, vol *model.Volume) (a []*model.Devic
 				return nil, err
 			}
 			device.Size = sizeInMiB
-
-			multipathdShowPaths, err := retryGetPathOfDevice(device, needActivePath)
+			var multipathdShowPaths [] *model.PathInfo
+			if vol.SecondaryArrayDetails != "" {
+				multipathdShowPaths, err = retryGetPathOfDevice(device, false)
+			} else {
+				multipathdShowPaths, err = retryGetPathOfDevice(device, needActivePath)
+			}
+			
 			if err != nil {
 				err = fmt.Errorf("unable to get scsi slaves for device:%s. Error: %s", device.SerialNumber, err.Error())
 				log.Debugf(err.Error())
@@ -492,8 +497,8 @@ func createLinuxDevice(volume *model.Volume) (dev *model.Device, err error) {
 				return d, nil
 			}
 			// Match TargetName/IQN only for VST type
-			if d.IscsiTarget != nil && volume.SerialNumber == "" && d.IscsiTarget.Name == volume.Iqn {
-				log.Debugf("Found device with matching target-name:%s scope:%s map:%s and slaves %+v", d.IscsiTarget.Name, d.IscsiTarget.Scope, d.AltFullPathName, d.Slaves)
+			if d.IscsiTarget[0] != nil && volume.SerialNumber == "" && d.IscsiTarget[0].Name == volume.Iqn {
+				log.Debugf("Found device with matching target-name:%s scope:%s map:%s and slaves %+v", d.IscsiTarget[0].Name, d.IscsiTarget[0].Scope, d.AltFullPathName, d.Slaves)
 				return d, nil
 			}
 		}

--- a/linux/device.go
+++ b/linux/device.go
@@ -305,14 +305,19 @@ func GetLinuxDmDevices(needActivePath bool, vol *model.Volume) (a []*model.Devic
 
 			isFC := isFibreChannelDevice(device.Slaves)
 			if !isFC {
-				iscsiTarget, err := iscsiGetTargetOfDevice(device)
+				iscsiTargets, err := iscsiGetTargetsOfDevice(device)
 				if err != nil {
 					log.Debugf("unable to get iscsi target for device %s. Error: %s", device.Pathname, err.Error())
 					continue
 					// continue with other devices, might be in offline state and IscsiTarget will be nil for this device
 				}
-				if iscsiTarget != nil {
-					device.IscsiTarget = iscsiTarget
+				if iscsiTargets[0] != nil {
+					if len(iscsiTargets) > 1 {
+						device.IscsiTargets = iscsiTargets  //for 3pardata
+					} else {
+						device.IscsiTargets[0] = iscsiTargets[0]  //non 3pardata
+					}
+				
 				}
 			}
 			if len(device.Slaves) > 0 {
@@ -497,8 +502,9 @@ func createLinuxDevice(volume *model.Volume) (dev *model.Device, err error) {
 				return d, nil
 			}
 			// Match TargetName/IQN only for VST type
-			if d.IscsiTarget[0] != nil && volume.SerialNumber == "" && d.IscsiTarget[0].Name == volume.Iqn {
-				log.Debugf("Found device with matching target-name:%s scope:%s map:%s and slaves %+v", d.IscsiTarget[0].Name, d.IscsiTarget[0].Scope, d.AltFullPathName, d.Slaves)
+			if d.IscsiTargets[0] != nil && volume.SerialNumber == "" && d.IscsiTargets[0].Name == volume.Iqn {
+				log.Debugf("Found device with matching target-name:%s scope:%s map:%s and slaves %+v", d.IscsiTargets[0].Name, d.IscsiTargets[0].Scope, d.AltFullPathName, d.Slaves)
+
 				return d, nil
 			}
 		}

--- a/linux/iscsi.go
+++ b/linux/iscsi.go
@@ -819,11 +819,12 @@ func removeDuplicateTargets(targets model.IscsiTargets) model.IscsiTargets {
 }
 
 // iscsiGetTargetOfDevice : get the iscsi target information of a device from sysfs
-func iscsiGetTargetOfDevice(dev *model.Device) (target *model.IscsiTarget, err error) {
+func iscsiGetTargetOfDevice(dev *model.Device) (target []*model.IscsiTarget, err error) {
 	log.Trace(">>>>> iscsiGetTargetOfDevice  with", dev)
 	defer log.Trace("<<<<< iscsiGetTargetOfDevice")
 
 	r := regexp.MustCompile(sessionIDPattern)
+	iscsiTargets := make([]*model.IscsiTarget, 0)
 	for _, hcil := range dev.Hcils {
 		host := strings.Split(hcil, ":")[0]
 		iscsiHostPath := fmt.Sprintf(hostDeviceFormat, host)
@@ -849,10 +850,16 @@ func iscsiGetTargetOfDevice(dev *model.Device) (target *model.IscsiTarget, err e
 			if err != nil {
 				return nil, fmt.Errorf("no iscsi target found from iscsi session %s", sessionID)
 			}
-			return iscsiTarget, nil
+			iscsiTargets = append(iscsiTargets, iscsiTarget)
 		}
 	}
-	return nil, nil
+	if iscsiTargets != nil {
+		return iscsiTargets, nil
+	
+	} else {
+		return nil, nil
+	}
+	
 }
 
 func getIscsiTargetFromSessionID(dev *model.Device, host string, sessionID string) (*model.IscsiTarget, error) {

--- a/linux/iscsi.go
+++ b/linux/iscsi.go
@@ -818,10 +818,10 @@ func removeDuplicateTargets(targets model.IscsiTargets) model.IscsiTargets {
 	return result
 }
 
-// iscsiGetTargetOfDevice : get the iscsi target information of a device from sysfs
-func iscsiGetTargetOfDevice(dev *model.Device) (target []*model.IscsiTarget, err error) {
-	log.Trace(">>>>> iscsiGetTargetOfDevice  with", dev)
-	defer log.Trace("<<<<< iscsiGetTargetOfDevice")
+// iscsiGetTargetsOfDevice : get the iscsi target information of a device from sysfs
+func iscsiGetTargetsOfDevice(dev *model.Device) (target []*model.IscsiTarget, err error) {
+	log.Trace(">>>>> iscsiGetTargetsOfDevice  with", dev)
+	defer log.Trace("<<<<< iscsiGetTargetsOfDevice")
 
 	r := regexp.MustCompile(sessionIDPattern)
 	iscsiTargets := make([]*model.IscsiTarget, 0)
@@ -853,12 +853,8 @@ func iscsiGetTargetOfDevice(dev *model.Device) (target []*model.IscsiTarget, err
 			iscsiTargets = append(iscsiTargets, iscsiTarget)
 		}
 	}
-	if iscsiTargets != nil {
-		return iscsiTargets, nil
+	return iscsiTargets, nil
 	
-	} else {
-		return nil, nil
-	}
 	
 }
 

--- a/linux/multipath.go
+++ b/linux/multipath.go
@@ -239,8 +239,8 @@ func cleanupDeviceAndSlaves(dev *model.Device) (err error) {
 	}
 
 	//delete all physical paths of the device
-	if (!isFC && dev.IscsiTarget != nil )&& (!isGst || dev.StorageVendor == "3PARdata") {
-		log.Debugf("volume scoped target %+v, initiating iscsi logout and delete", dev.IscsiTarget)
+	if (!isFC && dev.IscsiTargets != nil )&& (!isGst || dev.StorageVendor == "3PARdata") {
+		log.Debugf("volume scoped target %+v, initiating iscsi logout and delete", dev.IscsiTargets)
 		err = logoutAndDeleteIscsiTarget(dev)
 		if err != nil {
 			log.Error(err.Error())
@@ -286,8 +286,8 @@ func logoutAndDeleteIscsiTarget(dev *model.Device) error {
 	log.Tracef(">>>>> logoutAndDeleteIscsiTarget for device %s", dev.AltFullPathName)
 	defer log.Tracef("<<<<< logoutAndDeleteIscsiTarget")
 
-	if dev.IscsiTarget != nil {
-		for _, iscsiTarget := range dev.IscsiTarget {
+	if dev.IscsiTargets != nil {
+		for _, iscsiTarget := range dev.IscsiTargets {
 			log.Tracef("initiating the iscsi target logout for %s of type %s", iscsiTarget.Name, iscsiTarget.Scope)
 			//logout of iscsi target
 			err := iscsiLogoutOfTarget(iscsiTarget)

--- a/model/types.go
+++ b/model/types.go
@@ -150,7 +150,7 @@ type Device struct {
 	MpathName       string       `json:"mpath_device_name,omitempty"`
 	Size            int64        `json:"size,omitempty"` // size in MiB
 	Slaves          []string     `json:"slaves,omitempty"`
-	IscsiTarget     []*IscsiTarget `json:"iscsi_target,omitempty"`
+	IscsiTargets     []*IscsiTarget `json:"iscsi_target,omitempty"`
 	Hcils           []string     `json:"-"`                      // export it if needed
 	TargetScope     string       `json:"target_scope,omitempty"` //GST="group", VST="volume" or empty(older array fiji etc), and no-op for FC
 	State           string       `json:"state,omitempty"`        // state of the device needed to verify the device is active

--- a/model/types.go
+++ b/model/types.go
@@ -150,11 +150,12 @@ type Device struct {
 	MpathName       string       `json:"mpath_device_name,omitempty"`
 	Size            int64        `json:"size,omitempty"` // size in MiB
 	Slaves          []string     `json:"slaves,omitempty"`
-	IscsiTarget     *IscsiTarget `json:"iscsi_target,omitempty"`
+	IscsiTarget     []*IscsiTarget `json:"iscsi_target,omitempty"`
 	Hcils           []string     `json:"-"`                      // export it if needed
 	TargetScope     string       `json:"target_scope,omitempty"` //GST="group", VST="volume" or empty(older array fiji etc), and no-op for FC
 	State           string       `json:"state,omitempty"`        // state of the device needed to verify the device is active
 	Filesystem      string       `json:"filesystem,omitempty"`
+	StorageVendor   string       `json:"storage_vendor,omitempty"`  //3PARdata
 }
 
 // DevicePartition Partition Info for a Device

--- a/tunelinux/filesystem.go
+++ b/tunelinux/filesystem.go
@@ -27,7 +27,7 @@ func getRecommendationByFsOption(mountPoint *model.Mount, option string, current
 	var description = fsOptionDescriptionMap[option]
 
 	// ignore _netdev option for FC devices
-	if option == "_netdev" && mountPoint.Device.IscsiTarget == nil {
+	if option == "_netdev" && mountPoint.Device.IscsiTargets == nil {
 		return nil
 	}
 	// ignore discard option for ext3 based filesystems as its not supported


### PR DESCRIPTION
Problem statement:
There was an issue with iscsiadm logout step as part of the cleanup of deletedevices in NodeUnstageVolume. It deletes and logs out only 1 target node.
As part of nodeStageVolume, CSI creates deviceInfo.json and writes staging device information in it. But, it writes only one iscsiTarget info in it rather than a list

The mentioned PR has the fix for the multiple iscsi session logout.
It now writes the list of the iscsiTargets in deviceInfo.json file so that it logs out all the iscsi session.



