### PR TITLE
Adding FreeNAS support

### DIFF
--- a/linux/multipath.go
+++ b/linux/multipath.go
@@ -19,7 +19,7 @@ var (
 	showMapsFormat       = []string{"show", "maps", "format", "%w %d %n %s"}
 	orphanPathRegexp     = regexp.MustCompile(getOrphanPathsPattern())
 	multipathMutex       sync.Mutex
-	deviceVendorPatterns = []string{"Nimble", "3PARdata", "TrueNAS"}
+	deviceVendorPatterns = []string{"Nimble", "3PARdata", "TrueNAS", "FreeNAS"}
 )
 
 const (

--- a/tunelinux/config/multipath.conf.generic
+++ b/tunelinux/config/multipath.conf.generic
@@ -23,6 +23,10 @@ blacklist_exceptions {
         vendor  "TrueNAS"
         product "iSCSI Disk"
     }
+    device {
+        vendor  "FreeNAS"
+        product "iSCSI Disk"
+    }
 }
 devices {
     device {
@@ -44,6 +48,15 @@ devices {
         rr_weight            priorities
         uid_attribute        ID_SERIAL
         vendor               "TrueNAS"
+        product              "iSCSI Disk"
+        path_grouping_policy group_by_prio
+        path_selector        "queue-length 0"
+        hardware_handler     "1 alua"
+    }
+    device {
+        rr_weight            priorities
+        uid_attribute        ID_SERIAL
+        vendor               "FreeNAS"
         product              "iSCSI Disk"
         path_grouping_policy group_by_prio
         path_selector        "queue-length 0"

--- a/tunelinux/config/multipath.conf.upstream
+++ b/tunelinux/config/multipath.conf.upstream
@@ -25,6 +25,10 @@ blacklist_exceptions {
         vendor  "TrueNAS"
         product "iSCSI Disk"
     }
+    device {
+        vendor  "FreeNAS"
+        product "iSCSI Disk"
+    }
 }
 devices {
     device {
@@ -46,6 +50,15 @@ devices {
         rr_weight            priorities
         uid_attribute        ID_SERIAL
         vendor               "TrueNAS"
+        product              "iSCSI Disk"
+        path_grouping_policy group_by_prio
+        path_selector        "queue-length 0"
+        hardware_handler     "1 alua"
+    }
+    device {
+        rr_weight            priorities
+        uid_attribute        ID_SERIAL
+        vendor               "FreeNAS"
         product              "iSCSI Disk"
         path_grouping_policy group_by_prio
         path_selector        "queue-length 0"


### PR DESCRIPTION
This PR adds Device support for FreeNAS. It is a pre-req for [truenas-csp](https://github.com/hpe-storage/truenas-csp/issues/5) compatibility.