### PR TITLE
Enable scrubbing of sensitive information present in map

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -454,6 +454,8 @@ func IsSensitive(key string) bool {
 		"secret",
 		"token",
 		"accesskey",
+		"passPhrase",
+
 	}
 	key = strings.ToLower(key)
 	for _, bad := range badWords {
@@ -474,6 +476,20 @@ func Scrubber(args []string) []string {
 		}
 	}
 	return args
+}
+
+// MapScrubber checks if the map contains any sensitive information like username/password/secret
+// If found, then masks values for those keys, else copies the original value and returns new map
+func MapScrubber(m map[string]string) map[string]string {
+	retMap := make(map[string]string)
+	for k, v := range m {
+		if IsSensitive(k) {
+			retMap[k] = "**********"
+		} else {
+			retMap[k] = v
+		}
+	}
+	return retMap
 }
 
 // sourced adds a source field to the logger that contains

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -454,7 +454,7 @@ func IsSensitive(key string) bool {
 		"secret",
 		"token",
 		"accesskey",
-		"passPhrase",
+		"passphrase",
 
 	}
 	key = strings.ToLower(key)


### PR DESCRIPTION
Publish context map, which now contains sensitive encryption pass-phrase, was being logged in node_server:stageVolume() function. This PR would help scrub it before writing the map to log.

This is a pending change in the last PR on which csi-driver's PR https://github.com/hpe-storage/csi-driver/pull/246 is dependent on.

@raunakkumar - request you to review it following which I'll update the go.mod in csi-driver PR.