### PR TITLE
chapi: generate unique uuid for 2 hosts with same mac address

### DIFF
--- a/chapi/chapidriver_linux.go
+++ b/chapi/chapidriver_linux.go
@@ -72,7 +72,7 @@ func generateUniqueNodeId() (string, error) {
 	// sort mac addresses as best attempt to get same address even if node.gob is deleted
 	sort.Strings(macs)
 
-	// create a unique id using mac addess and host name using Md5 hash
+	// create a unique id using mac address and host name using Md5 hash
 	// https://github.com/hpe-storage/csi-driver/issues/270
 	idStr := util.GetMD5HashOfTwoStrings(strings.Replace(macs[0], ":", "", -1), hostName)
 	if len(idStr) < 32 {

--- a/chapi/chapidriver_linux.go
+++ b/chapi/chapidriver_linux.go
@@ -3,7 +3,6 @@
 package chapi
 
 import (
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -73,8 +72,9 @@ func generateUniqueNodeId() (string, error) {
 	// sort mac addresses as best attempt to get same address even if node.gob is deleted
 	sort.Strings(macs)
 
-	// create a unique id using mac addess and host name
-	idStr := strings.Replace(macs[0], ":", "", -1) + hex.EncodeToString([]byte(hostName))
+	// create a unique id using mac addess and host name using Md5 hash
+	// https://github.com/hpe-storage/csi-driver/issues/270
+	idStr := util.GetMD5HashOfTwoStrings(strings.Replace(macs[0], ":", "", -1), hostName)
 	if len(idStr) < 32 {
 		// pad with zeroes for minimum length
 		idStr += strings.Repeat("0", 32-len(idStr))

--- a/util/strings.go
+++ b/util/strings.go
@@ -4,7 +4,10 @@ package util
 
 import (
 	"bytes"
+	"crypto/md5"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"regexp"
 	"strings"
 )
@@ -45,4 +48,10 @@ func ConvertArrayOfIntToString(lun_ids []int32) string {
 		}
 	}
 	return buffer.String()
+}
+
+func GetMD5HashOfTwoStrings(string1, string2 string) string {
+	h := md5.New()
+	io.WriteString(h, string1+string2)
+	return hex.EncodeToString(h.Sum(nil))
 }

--- a/util/strings_test.go
+++ b/util/strings_test.go
@@ -1,3 +1,5 @@
+// (c) Copyright 2021 Hewlett Packard Enterprise Development LP
+
 package util
 
 import "testing"
@@ -9,6 +11,7 @@ func TestGetMacAddressHostNameMD5Hash(t *testing.T) {
 		hostName1   string
 		macAddress2 string
 		hostName2   string
+		expectSame  bool
 	}{
 		{
 			name:        "same mac address but different hostname",
@@ -16,6 +19,7 @@ func TestGetMacAddressHostNameMD5Hash(t *testing.T) {
 			macAddress2: "0a58a9fe0001",
 			hostName1:   "host-dev",
 			hostName2:   "host-prod",
+			expectSame:  false,
 		},
 		{
 			name:        "same hostname but different mac address",
@@ -23,6 +27,15 @@ func TestGetMacAddressHostNameMD5Hash(t *testing.T) {
 			macAddress2: "0a58a9fe0002",
 			hostName1:   "host-dev",
 			hostName2:   "host-dev",
+			expectSame:  false,
+		},
+		{
+			name:        "same hostname and same mac address",
+			macAddress1: "0a58a9fe0001",
+			macAddress2: "0a58a9fe0001",
+			hostName1:   "host-dev",
+			hostName2:   "host-dev",
+			expectSame:  true,
 		},
 	}
 
@@ -30,8 +43,11 @@ func TestGetMacAddressHostNameMD5Hash(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			idStr1 := GetMD5HashOfTwoStrings(tc.macAddress1, tc.hostName1)
 			idStr2 := GetMD5HashOfTwoStrings(tc.macAddress2, tc.hostName2)
-			if idStr1 == idStr2 {
+			if idStr1 == idStr2 && !tc.expectSame {
 				t.Fatalf("Expected %s to be different from %s for test %s", idStr1, idStr2, tc.name)
+			}
+			if idStr1 != idStr2 && tc.expectSame {
+				t.Fatalf("Expected %s to be same as %s for test %s", idStr1, idStr2, tc.name)
 			}
 		})
 	}

--- a/util/strings_test.go
+++ b/util/strings_test.go
@@ -1,0 +1,38 @@
+package util
+
+import "testing"
+
+func TestGetMacAddressHostNameMD5Hash(t *testing.T) {
+	testCases := []struct {
+		name        string
+		macAddress1 string
+		hostName1   string
+		macAddress2 string
+		hostName2   string
+	}{
+		{
+			name:        "same mac address but different hostname",
+			macAddress1: "0a58a9fe0001",
+			macAddress2: "0a58a9fe0001",
+			hostName1:   "host-dev",
+			hostName2:   "host-prod",
+		},
+		{
+			name:        "same hostname but different mac address",
+			macAddress1: "0a58a9fe0001",
+			macAddress2: "0a58a9fe0002",
+			hostName1:   "host-dev",
+			hostName2:   "host-dev",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			idStr1 := GetMD5HashOfTwoStrings(tc.macAddress1, tc.hostName1)
+			idStr2 := GetMD5HashOfTwoStrings(tc.macAddress2, tc.hostName2)
+			if idStr1 == idStr2 {
+				t.Fatalf("Expected %s to be different from %s for test %s", idStr1, idStr2, tc.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Problem:
As seen in issue https://github.com/hpe-storage/csi-driver/issues/270
Two hosts have same mac addresses and although their hostnames differ,
we generate the same uuid as the mechanism to generate uuid does not guarantee
uniqueness.
Update the mechanism to pass it through md5 has to guarantee uniqueness for 32 characters

Signed-off-by: Raunak <raunak.kumar@hpe.com>