### PR TITLE
chapi: busy or already mounted nfs mounts should be successfull

### DIFF
--- a/linux/mount.go
+++ b/linux/mount.go
@@ -589,6 +589,17 @@ func MountNFSShare(source string, targetPath string, options []string, nfsType s
 		nfsType = defaultNFSType
 	}
 
+	mountedSource := GetDeviceFromMountPoint(targetPath)
+	if mountedSource != "" {
+		// the source exists for the target path but differs from the expected mount, return error
+		if mountedSource != source {
+			err := fmt.Errorf("%s is already mounted at %s. Skipping mount for %s", mountedSource, source, targetPath)
+			return err
+		}
+		// if mount point present with expected targetPath, return successful
+		return nil
+	}
+
 	args := []string{fmt.Sprintf("-t%s", nfsType), source, targetPath}
 	optionArgs := []string{}
 	if len(options) != 0 {


### PR DESCRIPTION
Problem:
- just like regular pvc mounts, if the mounts for the volume already exist(
the previous command times out or other reasons) we treat the subsequent mount as success if the same
source and target are present. The same logic was missing for nfs mounts.

Signed-off-by: Raunak <raunak.kumar@hpe.com>