### PR TITLE
Support TrueNAS SCALE

### DIFF
--- a/tunelinux/config/multipath.conf.generic
+++ b/tunelinux/config/multipath.conf.generic
@@ -51,7 +51,6 @@ devices {
         product              "iSCSI Disk"
         path_grouping_policy group_by_prio
         path_selector        "queue-length 0"
-        hardware_handler     "1 alua"
     }
     device {
         rr_weight            priorities

--- a/tunelinux/config/multipath.conf.upstream
+++ b/tunelinux/config/multipath.conf.upstream
@@ -53,7 +53,6 @@ devices {
         product              "iSCSI Disk"
         path_grouping_policy group_by_prio
         path_selector        "queue-length 0"
-        hardware_handler     "1 alua"
     }
     device {
         rr_weight            priorities


### PR DESCRIPTION
Setting the hardware_handler to "1 alua" breaks for TrueNAS SCALE:
```
Oct 30 12:36:14 grisvakt-cpu3 kernel: sd 8:0:0:0: [sdb] Attached SCSI disk
Oct 30 12:36:15 grisvakt-cpu3 multipathd: sdb: add path (uevent)
Oct 30 12:36:15 grisvakt-cpu3 kernel: sd 7:0:0:0: alua: not supported
Oct 30 12:36:15 grisvakt-cpu3 kernel: sd 7:0:0:0: alua: not attached
Oct 30 12:36:15 grisvakt-cpu3 kernel: device-mapper: table: 252:0: multipath: error attaching hardware handler
Oct 30 12:36:15 grisvakt-cpu3 kernel: device-mapper: ioctl: error adding target to table
Oct 30 12:36:15 grisvakt-cpu3 multipathd: mpatha: failed in domap for addition of new path sdb
Oct 30 12:36:15 grisvakt-cpu3 multipathd: uevent trigger error
```

Removing the multipath.conf entry and it attaches fine.
```
Oct 30 12:41:08 grisvakt-cpu3 kernel: sd 22:0:0:0: [sdb] Attached SCSI disk
Oct 30 12:41:08 grisvakt-cpu3 multipathd: mpatha: load table [0 67108864 multipath 0 0 1 1 queue-length 0 1 1 8:0 1]
Oct 30 12:41:08 grisvakt-cpu3 multipathd: mpatha: event checker started
Oct 30 12:41:08 grisvakt-cpu3 multipathd: sda [8:0]: path added to devmap mpatha
Oct 30 12:41:08 grisvakt-cpu3 multipathd: sdb: add path (uevent)
Oct 30 12:41:08 grisvakt-cpu3 multipathd: mpatha: load table [0 67108864 multipath 0 0 1 1 queue-length 0 2 1 8:0 1 8:16 1]
Oct 30 12:41:08 grisvakt-cpu3 multipathd: sdb [8:16]: path added to devmap mpatha
```

Repeating the attach with hardware_handler "0", using TrueNAS CORE, ALUA seems to be detected anyhow:
```
Oct 30 13:12:30 grisvakt-cpu3 kernel: scsi 25:0:0:0: alua: supports implicit TPGS
Oct 30 13:12:30 grisvakt-cpu3 kernel: scsi 25:0:0:0: alua: device naa.6589cfc0000000e31e421641d7655045 port group 1 rel port 11
Oct 30 13:12:30 grisvakt-cpu3 kernel: scsi 25:0:0:0: alua: Attached
Oct 30 13:12:30 grisvakt-cpu3 kernel: sd 25:0:0:0: Attached scsi generic sg1 type 0
Oct 30 13:12:30 grisvakt-cpu3 kernel: sd 25:0:0:0: Power-on or device reset occurred
Oct 30 13:12:30 grisvakt-cpu3 kernel: sd 25:0:0:0: alua: rtpg retry
Oct 30 13:12:30 grisvakt-cpu3 kernel: sd 25:0:0:0: [alua] Sense Key : Unit Attention [current]
Oct 30 13:12:30 grisvakt-cpu3 kernel: sd 25:0:0:0: [alua] Add. Sense: Power on occurred
Oct 30 13:12:30 grisvakt-cpu3 kernel: sd 25:0:0:0: [sda] 67108864 512-byte logical blocks: (34.3 GB/32.0 GiB)
Oct 30 13:12:30 grisvakt-cpu3 kernel: sd 25:0:0:0: [sda] 8192-byte physical blocks
Oct 30 13:12:30 grisvakt-cpu3 kernel: sd 25:0:0:0: [sda] Write Protect is off
Oct 30 13:12:30 grisvakt-cpu3 kernel: sd 25:0:0:0: [sda] Write cache: enabled, read cache: enabled, supports DPO and FUA
Oct 30 13:12:30 grisvakt-cpu3 kernel: sd 25:0:0:0: [sda] Optimal transfer size 1048576 bytes
Oct 30 13:12:30 grisvakt-cpu3 kernel: sd 25:0:0:0: [sda] Attached SCSI disk
Oct 30 13:12:30 grisvakt-cpu3 multipathd: sda: add path (uevent)
Oct 30 13:12:30 grisvakt-cpu3 multipathd: mpathc: load table [0 67108864 multipath 0 0 1 1 queue-length 0 1 1 8:0 1]
Oct 30 13:12:30 grisvakt-cpu3 multipathd: mpathc: event checker started
Oct 30 13:12:30 grisvakt-cpu3 multipathd: sda [8:0]: path added to devmap mpathc
```

Hence removing the hardware_handler set to "1 alua" explicitly would seem safe. Although, messages differs slightly when attached using "1 alua":

```
Oct 30 13:33:11 grisvakt-cpu3 multipathd: sdb: add path (uevent)
Oct 30 13:33:11 grisvakt-cpu3 kernel: sd 29:0:0:0: alua: port group 01 state A non-preferred supports TolUSNA
Oct 30 13:33:11 grisvakt-cpu3 kernel: sd 29:0:0:0: alua: port group 01 state A non-preferred supports TolUSNA
Oct 30 13:33:11 grisvakt-cpu3 multipathd: sdb [8:16]: delaying path addition until mpathe is fully initialized
Oct 30 13:33:11 grisvakt-cpu3 multipathd: mpathe: performing delayed actions
Oct 30 13:33:11 grisvakt-cpu3 multipathd: mpathe: load table [0 67108864 multipath 0 1 alua 1 1 queue-length 0 2 1 8:0 1 8:16 1]
Oct 30 13:33:11 grisvakt-cpu3 kernel: sd 29:0:0:0: alua: port group 01 state A non-preferred supports TolUSNA
Oct 30 13:33:11 grisvakt-cpu3 kernel: sd 29:0:0:0: alua: port group 01 state A non-preferred supports TolUSNA
```

[TrueNAS SCALE docs](https://www.truenas.com/docs/scale/printview/) says ALUA is only supported on the Enterprise product of TrueNAS SCALE.

The fundamental problem is that there's no way to distinguish CORE and SCALE (or "Enterprise") from a device perspective, which is not ideal.

Signed-off-by: Michael Mattsson <michael.mattsson@gmail.com>