### PR TITLE
Formatting device with luks1 always

### DIFF
--- a/linux/device.go
+++ b/linux/device.go
@@ -528,7 +528,7 @@ func createLinuxDevice(volume *model.Volume) (dev *model.Device, err error) {
 					if !isLuksDev {
 						log.Infof("Device %s is a new device. LUKS formatting it...", originalDevPath)
 						_, _, err := util.ExecCommandOutputWithStdinArgs("cryptsetup",
-							[]string{"luksFormat", "--batch-mode", originalDevPath},
+							[]string{"luksFormat", "--type", "luks1", "--batch-mode", originalDevPath},
 							[]string{volume.EncryptionKey})
 						if err != nil {
 							err = fmt.Errorf("LUKS format command failed with error: %v", err)


### PR DESCRIPTION
@Pavan, @raunakkumar Please review

Fix for https://nimblejira.nimblestorage.com/browse/ESC-8915  

Resize for encrypted volumes on Redhat-8 is failing since the LUKS type is LUKS2 and key location: keyring which requires the passphrase.
Currently there is no option to pass the passphrase to stage volume.
If we format the device with LUKS1 instead LUKS2 the key location will be always dm-crypt .

[root@c3-sy480g10-20 ~]# cryptsetup status -v /dev/mapper/enc-mpathbcw
/dev/mapper/enc-mpathbcw is active and is in use.
  **type:    LUKS1**
  cipher:  aes-xts-plain64
  keysize: 512 bits
  **key location: dm-crypt**
  device:  /dev/mapper/mpathbcw
  sector size:  512
  offset:  32768 sectors
  size:    39813120 sectors
  mode:    read/write
Command successful.


