### PR TITLE
Update cmd.go

### DIFF
--- a/util/cmd.go
+++ b/util/cmd.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	defaultTimeout = 60
+	defaultTimeout = 300
 )
 
 func execCommandOutputWithTimeout(cmd string, args []string, stdinArgs []string, timeout int) (string, int, error) {
@@ -82,7 +82,7 @@ func execCommandOutputWithTimeout(cmd string, args []string, stdinArgs []string,
 
 // ExecCommandOutputWithTimeout  executes ExecCommandOutput with the specified timeout
 func ExecCommandOutputWithTimeout(cmd string, args []string, timeout int) (string, int, error) {
-	return execCommandOutputWithTimeout(cmd, args, []string{}, defaultTimeout)
+	return execCommandOutputWithTimeout(cmd, args, []string{}, timeout)
 }
 // ExecCommandOutput returns stdout and stderr in a single string, the return code, and error.
 // If the return code is not zero, error will not be nil.


### PR DESCRIPTION
fixing an issue where the timeout for creating the filesystem is not 300 sec causing it to fail when creating large size volumes. this is because ExecCommandOutputWithTimeout receives a parameter "timeout" but then always runs execCommandOutputWithTimeout with "defaultTimeout" instead of passing the "timeout"