### PR TITLE
CON2508: Handling the Cleanup  of stale multipath devices

### DIFF
--- a/chapi/chapidriver_linux.go
+++ b/chapi/chapidriver_linux.go
@@ -351,7 +351,7 @@ func (driver *LinuxDriver) IsFileSystemCorrupted(volumeID string, device *model.
 }
 
 func getInfoFromTune2fsOutput(output string, pattern string) string {
-	log.Tracef(">>>>> getInfoFromTune2fsOutput, Pattern:", pattern)
+	log.Tracef(">>>>> getInfoFromTune2fsOutput, Pattern: %s", pattern)
 	defer log.Trace("<<<<< getInfoFromTune2fsOutput")
 	lines := strings.Split(output, "\n")
 	var relevantInfo string
@@ -489,7 +489,7 @@ func (driver *LinuxDriver) RepairFsckFileSystem(volumeID string, device *model.D
 				case 128:
 					return fmt.Errorf("Shared library error for the device %s.", device.AltFullPathName)
 				default:
-					return fmt.Errorf("Unknown exit code: %d\n", status.ExitStatus)
+					return fmt.Errorf("Unknown exit code: %d\n", status.ExitStatus())
 				}
 			} else {
 				// send the error code and stderr content to the caller

--- a/model/types.go
+++ b/model/types.go
@@ -450,3 +450,10 @@ type MultipathDevice struct {
 	} `json:"path_groups,omitempty"`
 	IsUnhealthy bool // Custom field added to capture whether the multipath device is healthy or not
 }
+
+type ProcMount struct {
+	Device     string `json:"device,omitempty"`
+	MountPoint string `json:"Mountpoint,omitempty"`
+	FileSystem string `json:"FileSystem,omitempty"`
+	Options    string `json:"Options,omitempty"`
+}

--- a/model/types.go
+++ b/model/types.go
@@ -402,14 +402,51 @@ type KeyValue struct {
 	Value string `json:"value,omitempty"`
 }
 
-// This is not a complete information of the multipath device.
-// A few fields are included that can be used to determine whether
-// the device is healthy or not
-type MultipathDeviceInfo struct {
-	Name        string
-	Vendor      string
-	Paths       float64
-	PathFaults  float64
-	UUID        string
-	IsUnhealthy bool
+type MultipathInfo struct {
+	MajorVersion int               `json:"major_version,omitempty"`
+	MinorVersion int               `json:"minor_version,omitempty"`
+	Maps         []MultipathDevice `json:"maps,omitempty"`
+}
+
+type MultipathDevice struct {
+	Name       string `json:"name,omitempty"`
+	UUID       string `json:"uuid,omitempty"`
+	Sysfs      string `json:"sysfs,omitempty"`
+	Failback   string `json:"failback,omitempty"`
+	Queueing   string `json:"queueing,omitempty"`
+	Paths      int    `json:"paths,omitempty"`
+	WriteProt  string `json:"write_prot,omitempty"`
+	DmSt       string `json:"dm_st,omitempty"`
+	Features   string `json:"features,omitempty"`
+	Hwhandler  string `json:"hwhandler,omitempty"`
+	Action     string `json:"action,omitempty"`
+	PathFaults int    `json:"path_faults,omitempty"`
+	Vend       string `json:"vend,omitempty"`
+	Prod       string `json:"prod,omitempty"`
+	Rev        string `json:"rev,omitempty"`
+	SwitchGrp  int    `json:"switch_grp,omitempty"`
+	MapLoads   int    `json:"map_loads,omitempty"`
+	TotalQTime int    `json:"total_q_time,omitempty"`
+	QTimeouts  int    `json:"q_timeouts,omitempty"`
+	PathGroups []struct {
+		Selector string `json:"selector,omitempty"`
+		Pri      int    `json:"pri,omitempty"`
+		DmSt     string `json:"dm_st,omitempty"`
+		Group    int    `json:"group,omitempty"`
+		Paths    []struct {
+			Dev         string `json:"dev,omitempty"`
+			DevT        string `json:"dev_t,omitempty"`
+			DmSt        string `json:"dm_st,omitempty"`
+			DevSt       string `json:"dev_st,omitempty"`
+			ChkSt       string `json:"chk_st,omitempty"`
+			Checker     string `json:"checker,omitempty"`
+			Pri         int    `json:"pri,omitempty"`
+			HostWwnn    string `json:"host_wwnn,omitempty"`
+			TargetWwnn  string `json:"target_wwnn,omitempty"`
+			HostWwpn    string `json:"host_wwpn,omitempty"`
+			TargetWwpn  string `json:"target_wwpn,omitempty"`
+			HostAdapter string `json:"host_adapter,omitempty"`
+		} `json:"paths,omitempty"`
+	} `json:"path_groups,omitempty"`
+	IsUnhealthy bool // Custom field added to capture whether the multipath device is healthy or not
 }

--- a/tunelinux/multipath.go
+++ b/tunelinux/multipath.go
@@ -458,9 +458,10 @@ func getBlockDevicesOfMultipathDevice(device model.MultipathDevice) (blockDevice
 }
 
 func removeBlockDevices(blockDevices []string, multipathDevice string) error {
-	log.Trace(">>>> removeBlockDevices")
+	log.Trace(">>>> removeBlockDevices: ", blockDevices)
 	defer log.Trace("<<<<< removeBlockDevices")
 	for _, blockDevice := range blockDevices {
+		("Removing the block device %s of multipath device %s", blockDevice, multipathDevice)
 		cmd := exec.Command("sh", "-c", "echo 1 > /sys/block/"+blockDevice+"/device/delete")
 		err := cmd.Run()
 		if err != nil {

--- a/tunelinux/multipath.go
+++ b/tunelinux/multipath.go
@@ -643,11 +643,12 @@ func listTheProcessesUsingDevice(multipathDevice string) error {
 	args := []string{"-mv", "dev/mapper/" + multipathDevice}
 	output, _, err := util.ExecCommandOutput("fuser", args)
 	if err != nil {
-		log.Errorf("unable to list the processes using the mount poing %s using fuser command: %s", mountPoint, err.Error())
+		log.Errorf("unable to list the processes using the mount poing %s using fuser command: %s", multipathDevice, err.Error())
 		return err
 	}
 	log.Infof("Processes using the multipath device %s are:", multipathDevice)
 	log.Infof(output)
+	return nil
 }
 func displayDeviceInfo(multipathDevice string) error {
 	log.Tracef(">>>> displayDeviceInfo: %s", multipathDevice)

--- a/tunelinux/multipath.go
+++ b/tunelinux/multipath.go
@@ -617,21 +617,21 @@ func FlushMultipathDevice(multipathDevice string) error {
 	_, _, err := util.ExecCommandOutput("multipath", []string{"-f", multipathDevice})
 	if err != nil {
 		log.Errorf("Error occured while removing the multipath device %s: %s", multipathDevice, err.Error())
-		if strings.Contains(err.Error(), "map in use") {
-			log.Infof("Trying to remove the multipath device %s using dmsetup command", multipathDevice)
-			err = displayDeviceInfo(multipathDevice)
-			if err != nil {
-				log.Errorf("Error while displaying the device info %s", multipathDevice)
-			}
-			err = listTheProcessesUsingDevice(multipathDevice)
-			if err != nil {
-				log.Errorf("Error while displaying the processes using the device info %s", multipathDevice)
-			}
-			err = forceDeleteMultipathDevice(multipathDevice)
-			if err != nil {
-				return fmt.Errorf("Unable to remove th multipath device %s by force as well: %s", multipathDevice, err.Error())
-			}
+
+		log.Infof("Trying to remove the multipath device %s using dmsetup command", multipathDevice)
+		err = displayDeviceInfo(multipathDevice)
+		if err != nil {
+			log.Errorf("Error while displaying the device info %s", multipathDevice)
 		}
+		err = listTheProcessesUsingDevice(multipathDevice)
+		if err != nil {
+			log.Errorf("Error while displaying the processes using the device info %s", multipathDevice)
+		}
+		err = forceDeleteMultipathDevice(multipathDevice)
+		if err != nil {
+			return fmt.Errorf("Unable to remove th multipath device %s by force as well: %s", multipathDevice, err.Error())
+		}
+
 		return err
 	}
 	log.Debugf("Multipath device %s is removed successfully.", multipathDevice)

--- a/tunelinux/multipath.go
+++ b/tunelinux/multipath.go
@@ -640,7 +640,7 @@ func FlushMultipathDevice(multipathDevice string) error {
 
 func listTheProcessesUsingDevice(multipathDevice string) error {
 	log.Tracef(">>>> listTheProcessesUsingDevice: %s", multipathDevice)
-	args := []string{"-mv", "dev/mapper/" + multipathDevice}
+	args := []string{"-mv", "/dev/mapper/" + multipathDevice}
 	output, _, err := util.ExecCommandOutput("fuser", args)
 	if err != nil {
 		log.Errorf("unable to list the processes using the mount poing %s using fuser command: %s", multipathDevice, err.Error())

--- a/tunelinux/multipath.go
+++ b/tunelinux/multipath.go
@@ -33,7 +33,8 @@ var (
 		"Nimble": "(?s)devices\\s+{\\s*.*device\\s*{(?P<device_block>.*Nimble.*?)}",
 		"3par":   "(?s)devices\\s+{\\s*.*device\\s*{(?P<device_block>.*3PAR.*?)}",
 	}
-	mountMutex sync.Mutex
+	mountMutex  sync.Mutex
+	umountMutex sync.Mutex
 )
 
 // GetMultipathConfigFile returns path of the template multipath.conf file according to OS distro
@@ -485,6 +486,9 @@ func UnmountMultipathDevice(multipathDevice string) error {
 		return nil
 	}
 
+	umountMutex.Lock()
+	defer umountMutex.Unlock()
+
 	for _, mountPoint := range mountPoints {
 		err = unmount(mountPoint)
 		if err != nil {
@@ -507,6 +511,7 @@ func UnmountMultipathDevice(multipathDevice string) error {
 
 func unmount(mountPoint string) error {
 	log.Tracef("Unmout the mount point %s", mountPoint)
+
 	args := []string{mountPoint}
 	_, rc, err := util.ExecCommandOutput("umount", args)
 	if err != nil || rc != 0 {

--- a/tunelinux/multipath.go
+++ b/tunelinux/multipath.go
@@ -404,7 +404,7 @@ func GetMultipathDevices() (multipathDevices []model.MultipathDevice, err error)
 
 		for _, mapItem := range multipathJson.Maps {
 			if len(mapItem.Vend) > 0 && isSupportedDeviceVendor(linux.DeviceVendorPatterns, mapItem.Vend) {
-				if mapItem.Paths < 1 && mapItem.PathFaults > 0 {
+				if mapItem.Paths < 1 || mapItem.PathFaults > 0 {
 					mapItem.IsUnhealthy = true
 				}
 				multipathDevices = append(multipathDevices, mapItem)
@@ -550,8 +550,17 @@ func KillProcessesUisngMountPoints(mountPoint string) error {
 				continue
 			}
 			lineItems := strings.Fields(string(line))
-			if len(lineItems) > 1 && lineItems[1] != "" {
-				pid, err := strconv.Atoi(lineItems[1])
+			if len(lineItems) > 1 {
+				pidStr := ""
+				if len(lineItems) > 4 && lineItems[2] != "" {
+					pidStr = lineItems[2]
+				} else if len(lineItems) == 4 && lineItems[1] != "" {
+					pidStr = lineItems[1]
+				}
+				if len(pidStr) == 0 {
+					continue
+				}
+				pid, err := strconv.Atoi(pidStr)
 				if err != nil {
 					log.Errorf("Error converting PID:%s", err)
 					continue

--- a/tunelinux/multipath.go
+++ b/tunelinux/multipath.go
@@ -384,7 +384,7 @@ func ConfigureMultipath() (err error) {
 	return nil
 }
 
-func GetMultipathDevices() (multipathDevices []*model.MultipathDevice, err error) {
+func GetMultipathDevices() (multipathDevices []model.MultipathDevice, err error) {
 	log.Tracef(">>>> getMultipathDevices ")
 	defer log.Trace("<<<<< getMultipathDevices")
 
@@ -406,7 +406,7 @@ func GetMultipathDevices() (multipathDevices []*model.MultipathDevice, err error
 				if mapItem.Paths < 1 && mapItem.PathFaults > 0 {
 					mapItem.IsUnhealthy = true
 				}
-				multipathDevices = append(multipathDevices, &mapItem)
+				multipathDevices = append(multipathDevices, mapItem)
 				log.Tracef("Multipath device: %s", mapItem.Name)
 			}
 		}

--- a/tunelinux/multipath.go
+++ b/tunelinux/multipath.go
@@ -461,7 +461,7 @@ func removeBlockDevices(blockDevices []string, multipathDevice string) error {
 	log.Trace(">>>> removeBlockDevices: ", blockDevices)
 	defer log.Trace("<<<<< removeBlockDevices")
 	for _, blockDevice := range blockDevices {
-		("Removing the block device %s of multipath device %s", blockDevice, multipathDevice)
+		log.Debugf("Removing the block device %s of multipath device %s", blockDevice, multipathDevice)
 		cmd := exec.Command("sh", "-c", "echo 1 > /sys/block/"+blockDevice+"/device/delete")
 		err := cmd.Run()
 		if err != nil {

--- a/tunelinux/multipath.go
+++ b/tunelinux/multipath.go
@@ -407,8 +407,10 @@ func GetMultipathDevices() (multipathDevices []*model.MultipathDevice, err error
 					mapItem.IsUnhealthy = true
 				}
 				multipathDevices = append(multipathDevices, &mapItem)
+				log.Tracef("Multipath device: %s", mapItem.Name)
 			}
 		}
+		log.Infof("Found %d multipath devices %+v", len(multipathDevices), multipathDevices)
 		return multipathDevices, nil
 	}
 	return nil, fmt.Errorf("Invalid multipathd command output received")

--- a/tunelinux/multipath.go
+++ b/tunelinux/multipath.go
@@ -404,7 +404,7 @@ func GetMultipathDevices() (multipathDevices []model.MultipathDevice, err error)
 
 		for _, mapItem := range multipathJson.Maps {
 			if len(mapItem.Vend) > 0 && isSupportedDeviceVendor(linux.DeviceVendorPatterns, mapItem.Vend) {
-				if mapItem.Paths < 1 || mapItem.PathFaults > 0 {
+				if mapItem.Paths < 1 && mapItem.PathFaults > 0 {
 					mapItem.IsUnhealthy = true
 				}
 				multipathDevices = append(multipathDevices, mapItem)
@@ -496,7 +496,7 @@ func UnmountMultipathDevice(multipathDevice string) error {
 		err = unmount(mountPoint)
 		if err != nil {
 			log.Warnf("Error occurred while unmounting %s. Trying to find processes using this mount point...", mountPoint)
-			err = KillProcessesUisngMountPoints(mountPoint)
+			err = KillProcessesUsingMountPoints(mountPoint)
 			if err != nil {
 				return fmt.Errorf("Unable to kill the processes using the mount point %s: %s", mountPoint, err.Error())
 			}
@@ -524,9 +524,9 @@ func unmount(mountPoint string) error {
 	return nil
 }
 
-func KillProcessesUisngMountPoints(mountPoint string) error {
-	log.Tracef(">>>> KillProcessesUisngMountPoints: %s", mountPoint)
-	defer log.Trace("<<<<< KillProcessesUisngMountPoints")
+func KillProcessesUsingMountPoints(mountPoint string) error {
+	log.Tracef(">>>> KillProcessesUsingMountPoints: %s", mountPoint)
+	defer log.Trace("<<<<< KillProcessesUsingMountPoints")
 
 	staleDeviceRemovalMutex.Lock()
 	defer staleDeviceRemovalMutex.Unlock()


### PR DESCRIPTION
The following functionalities are implemented in phase 3:

1. Unmount all references to the device, bind mounts, and real mounts.
2. Kill processes using the mount points and devices
3. Remove block devices
4. Flush the multipath map

made improvements for the previous  phase's implementation as well