### PR TITLE
CON-4772 optimize GetMultiPathDevices function

### DIFF
--- a/linux/multipath.go
+++ b/linux/multipath.go
@@ -77,7 +77,7 @@ func MultipathdReconfigure() (out string, err error) {
 	return out, err
 }
 
-func isMultipathTimeoutError(msg string) bool {
+func IsMultipathTimeoutError(msg string) bool {
 	return strings.Contains(msg, "timeout") || strings.Contains(msg, "receiving packet")
 }
 
@@ -94,7 +94,7 @@ func multipathShowCmdOrphanPaths() (output []string, err error) {
 		return nil, err
 	}
 	// rc can be 0 on the below error conditions as well
-	if isMultipathTimeoutError(out) {
+	if IsMultipathTimeoutError(out) {
 		err = fmt.Errorf("failed to get multipathd %v, out %s", showPathsFormat, out)
 		log.Warn(err.Error())
 		return nil, err
@@ -114,7 +114,7 @@ func multipathdShowCmd(args []string, serialNumber string) (output []string, err
 		return nil, err
 	}
 	// rc can be 0 on the below error conditions as well
-	if isMultipathTimeoutError(out) {
+	if IsMultipathTimeoutError(out) {
 		err = fmt.Errorf("failed to get multipathd %v, out %s", args, out)
 		log.Warn(err.Error())
 		return nil, err
@@ -225,14 +225,13 @@ func cleanupDeviceAndSlaves(dev *model.Device) (err error) {
 	log.Tracef(">>>>> cleanupDeviceAndSlaves called for %+v", dev)
 	defer log.Trace("<<<<< cleanupDeviceAndSlaves")
 
-
 	// --- NVMe multipath handling ---
-    if dev != nil && dev.Pathname != "" && IsNvmeDevice(dev.Pathname) {
-        if err := HandleMultipathForDevice(dev); err != nil {
-        	return err
-    	}
-    }
-    // --- End NVMe multipath handling ---
+	if dev != nil && dev.Pathname != "" && IsNvmeDevice(dev.Pathname) {
+		if err := HandleMultipathForDevice(dev); err != nil {
+			return err
+		}
+	}
+	// --- End NVMe multipath handling ---
 
 	isFC := isFibreChannelDevice(dev.Slaves)
 
@@ -408,7 +407,7 @@ func retryGetPathOfDevice(dev *model.Device, needActivePath bool) (paths []*mode
 	for {
 		paths, err := multipathGetPathsOfDevice(dev, needActivePath)
 		if err != nil {
-			if isMultipathTimeoutError(err.Error()) {
+			if IsMultipathTimeoutError(err.Error()) {
 				if try < maxTries {
 					try++
 					time.Sleep(5 * time.Second)
@@ -544,36 +543,38 @@ func multipathGetPathsOfDevice(dev *model.Device, needActivePath bool) (paths []
 	}
 	return paths, nil
 }
+
 // IsNvmeDevice returns true if the device path is an NVMe device (e.g., /dev/nvmeXnY)
 func IsNvmeDevice(devPath string) bool {
-    base := filepath.Base(devPath)
-    matched, _ := regexp.MatchString(`^nvme\d+n\d+$`, base)
-    return matched
+	base := filepath.Base(devPath)
+	matched, _ := regexp.MatchString(`^nvme\d+n\d+$`, base)
+	return matched
 }
 
 // IsNvmeMultipathEnabled checks if NVMe native multipath is enabled for a device
 func IsNvmeMultipathEnabled(devPath string) bool {
-    base := filepath.Base(devPath)
-    nvmeMpPath := filepath.Join("/sys/class/block", base, "nvme_multipath")
-    data, err := ioutil.ReadFile(nvmeMpPath)
-    if err != nil {
-        return false
-    }
-    return strings.TrimSpace(string(data)) == "Y"
+	base := filepath.Base(devPath)
+	nvmeMpPath := filepath.Join("/sys/class/block", base, "nvme_multipath")
+	data, err := ioutil.ReadFile(nvmeMpPath)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(data)) == "Y"
 }
+
 // HandleMultipathForDevice handles multipath for both SCSI and NVMe devices
 func HandleMultipathForDevice(dev *model.Device) error {
-   
-    if IsNvmeDevice(dev.Pathname) {
-        if IsNvmeMultipathEnabled(dev.Pathname) {
-            log.Debugf("NVMe native multipath is enabled for %s, skipping dm-multipath logic", dev.Pathname)
-            // All path management is handled by the NVMe subsystem
-            return nil
-        }
-        log.Debugf("NVMe device %s does not have native multipath enabled", dev.Pathname)
-        // TODO: later we will need it when dm-multipath for NVMe is supported
-        // return handleDmMultipathForNvme(dev)
-        return nil
-    }
-    return nil
+
+	if IsNvmeDevice(dev.Pathname) {
+		if IsNvmeMultipathEnabled(dev.Pathname) {
+			log.Debugf("NVMe native multipath is enabled for %s, skipping dm-multipath logic", dev.Pathname)
+			// All path management is handled by the NVMe subsystem
+			return nil
+		}
+		log.Debugf("NVMe device %s does not have native multipath enabled", dev.Pathname)
+		// TODO: later we will need it when dm-multipath for NVMe is supported
+		// return handleDmMultipathForNvme(dev)
+		return nil
+	}
+	return nil
 }

--- a/tunelinux/multipath.go
+++ b/tunelinux/multipath.go
@@ -393,50 +393,52 @@ func GetMultipathDevices() (multipathDevices []model.MultipathDevice, err error)
 		return nil, fmt.Errorf("Failed to get the multipath devices due to the error: %s", err.Error())
 	}
 
-	if out != "" {
-		multipathJson := new(model.MultipathInfo)
-		//err = json.Unmarshal([]byte(out), multipathJson)
-		decoder := json.NewDecoder(strings.NewReader(out))
-		err = decoder.Decode(multipathJson)
-		if err != nil {
-			return nil, fmt.Errorf("Invalid JSON output of multipathd command: %s", err.Error())
+	out = strings.TrimSpace(out)
+	if out == "" {
+		log.Infof("No multipath devices found")
+		return nil, nil
+	}
+
+	multipathJson := new(model.MultipathInfo)
+	decoder := json.NewDecoder(strings.NewReader(out))
+	err = decoder.Decode(multipathJson)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid JSON output of multipathd command: %s", err.Error())
+	}
+	var extra interface{}
+	if err = decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			err = fmt.Errorf("unexpected data after JSON object")
 		}
-		var extra interface{}
-		if err = decoder.Decode(&extra); err != io.EOF {
-			if err == nil {
-				err = fmt.Errorf("unexpected data after JSON object")
-			}
-			return nil, fmt.Errorf("Invalid JSON output of multipathd command: %s", err.Error())
-		}
+		return nil, fmt.Errorf("Invalid JSON output of multipathd command: %s", err.Error())
+	}
 
-		multipathDevices = make([]model.MultipathDevice, 0, len(multipathJson.Maps))
-		unhealthyDeviceCount := 0
-		orphanDeviceCount := 0
+	multipathDevices = make([]model.MultipathDevice, 0, len(multipathJson.Maps))
+	unhealthyDeviceCount := 0
+	orphanDeviceCount := 0
 
-		for _, mapItem := range multipathJson.Maps {
-			if len(mapItem.Vend) > 0 && isSupportedDeviceVendor(linux.DeviceVendorPatterns, mapItem.Vend) {
-				if mapItem.Paths < 1 && mapItem.PathFaults > 0 {
-					mapItem.IsUnhealthy = true
-					unhealthyDeviceCount++
-					log.Tracef("Known unhealthy multipath device: %s", mapItem.Name)
-				}
-				multipathDevices = append(multipathDevices, mapItem)
-				continue
-			}
-
-			// residual non-functional multipath devices
-			if len(mapItem.PathGroups) == 0 && mapItem.Queueing == "off" && mapItem.Features == "0" {
+	for _, mapItem := range multipathJson.Maps {
+		if len(mapItem.Vend) > 0 && isSupportedDeviceVendor(linux.DeviceVendorPatterns, mapItem.Vend) {
+			if mapItem.Paths < 1 && mapItem.PathFaults > 0 {
 				mapItem.IsUnhealthy = true
 				unhealthyDeviceCount++
-				orphanDeviceCount++
-				log.Tracef("Unknown orphan multipath device without path_groups: %s", mapItem.Name)
-				multipathDevices = append(multipathDevices, mapItem)
+				log.Tracef("Known unhealthy multipath device: %s", mapItem.Name)
 			}
+			multipathDevices = append(multipathDevices, mapItem)
+			continue
 		}
-		log.Infof("Found %d multipath devices (%d unhealthy, %d orphan)", len(multipathDevices), unhealthyDeviceCount, orphanDeviceCount)
-		return multipathDevices, nil
+
+		// residual non-functional multipath devices
+		if len(mapItem.PathGroups) == 0 && mapItem.Queueing == "off" && mapItem.Features == "0" {
+			mapItem.IsUnhealthy = true
+			unhealthyDeviceCount++
+			orphanDeviceCount++
+			log.Tracef("Unknown orphan multipath device without path_groups: %s", mapItem.Name)
+			multipathDevices = append(multipathDevices, mapItem)
+		}
 	}
-	return nil, fmt.Errorf("Invalid multipathd command output received")
+	log.Infof("Found %d multipath devices (%d unhealthy, %d orphan)", len(multipathDevices), unhealthyDeviceCount, orphanDeviceCount)
+	return multipathDevices, nil
 }
 
 func isSupportedDeviceVendor(deviceVendors []string, vendor string) bool {

--- a/tunelinux/multipath.go
+++ b/tunelinux/multipath.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -394,15 +395,29 @@ func GetMultipathDevices() (multipathDevices []model.MultipathDevice, err error)
 
 	if out != "" {
 		multipathJson := new(model.MultipathInfo)
-		err = json.Unmarshal([]byte(out), multipathJson)
+		//err = json.Unmarshal([]byte(out), multipathJson)
+		decoder := json.NewDecoder(strings.NewReader(out))
+		err = decoder.Decode(multipathJson)
 		if err != nil {
 			return nil, fmt.Errorf("Invalid JSON output of multipathd command: %s", err.Error())
 		}
+		var extra interface{}
+		if err = decoder.Decode(&extra); err != io.EOF {
+			if err == nil {
+				err = fmt.Errorf("unexpected data after JSON object")
+			}
+			return nil, fmt.Errorf("Invalid JSON output of multipathd command: %s", err.Error())
+		}
+
+		multipathDevices = make([]model.MultipathDevice, 0, len(multipathJson.Maps))
+		unhealthyDeviceCount := 0
+		orphanDeviceCount := 0
 
 		for _, mapItem := range multipathJson.Maps {
 			if len(mapItem.Vend) > 0 && isSupportedDeviceVendor(linux.DeviceVendorPatterns, mapItem.Vend) {
 				if mapItem.Paths < 1 && mapItem.PathFaults > 0 {
 					mapItem.IsUnhealthy = true
+					unhealthyDeviceCount++
 					log.Tracef("Known unhealthy multipath device: %s", mapItem.Name)
 				}
 				multipathDevices = append(multipathDevices, mapItem)
@@ -412,11 +427,13 @@ func GetMultipathDevices() (multipathDevices []model.MultipathDevice, err error)
 			// residual non-functional multipath devices
 			if len(mapItem.PathGroups) == 0 && mapItem.Queueing == "off" && mapItem.Features == "0" {
 				mapItem.IsUnhealthy = true
+				unhealthyDeviceCount++
+				orphanDeviceCount++
 				log.Tracef("Unknown orphan multipath device without path_groups: %s", mapItem.Name)
 				multipathDevices = append(multipathDevices, mapItem)
 			}
 		}
-		log.Infof("Found %d multipath devices %+v", len(multipathDevices), multipathDevices)
+		log.Infof("Found %d multipath devices (%d unhealthy, %d orphan)", len(multipathDevices), unhealthyDeviceCount, orphanDeviceCount)
 		return multipathDevices, nil
 	}
 	return nil, fmt.Errorf("Invalid multipathd command output received")

--- a/tunelinux/multipath.go
+++ b/tunelinux/multipath.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/hpe-storage/common-host-libs/linux"
 	log "github.com/hpe-storage/common-host-libs/logger"
@@ -23,7 +24,9 @@ import (
 )
 
 const (
-	multipath = "multipath"
+	multipath                  = "multipath"
+	multipathTimeoutMaxTries   = 3
+	multipathTimeoutRetrySleep = 2 * time.Second
 
 	// uxsockTimeoutParam is the multipath.conf defaults-section key that controls
 	// the unix domain socket timeout (in milliseconds) used by multipathd.
@@ -50,6 +53,7 @@ var (
 	umountMutex             sync.Mutex
 	staleDeviceRemovalMutex sync.Mutex
 	readProcMountsMutex     sync.Mutex
+	ErrMultipathTimeout     = errors.New("multipathd timeout")
 )
 
 // GetMultipathConfigFile returns path of the template multipath.conf file according to OS distro
@@ -387,10 +391,29 @@ func GetMultipathDevices() (multipathDevices []model.MultipathDevice, err error)
 	log.Tracef(">>>> getMultipathDevices ")
 	defer log.Trace("<<<<< getMultipathDevices")
 
-	out, _, err := util.ExecCommandOutput("multipathd", []string{"show", "multipaths", "json"})
+	for try := 1; try <= multipathTimeoutMaxTries; try++ {
+		out, _, cmdErr := util.ExecCommandOutput("multipathd", []string{"show", "multipaths", "json"})
 
-	if err != nil {
-		return nil, fmt.Errorf("Failed to get the multipath devices due to the error: %s", err.Error())
+		multipathDevices, err = parseMultipathDevices(out)
+		if errors.Is(err, ErrMultipathTimeout) {
+			if try == multipathTimeoutMaxTries {
+				return nil, fmt.Errorf("failed to get the multipath devices after %d attempts: %w", multipathTimeoutMaxTries, err)
+			}
+			log.Warnf("Transient multipathd timeout while getting multipath devices; retrying attempt %d of %d", try+1, multipathTimeoutMaxTries)
+			time.Sleep(multipathTimeoutRetrySleep)
+			continue
+		}
+		if cmdErr != nil {
+			return nil, fmt.Errorf("failed to get the multipath devices due to the error: %s", cmdErr.Error())
+		}
+		return multipathDevices, err
+	}
+	return nil, ErrMultipathTimeout
+}
+
+func parseMultipathDevices(out string) (multipathDevices []model.MultipathDevice, err error) {
+	if linux.IsMultipathTimeoutError(out) {
+		return nil, ErrMultipathTimeout
 	}
 
 	out = strings.TrimSpace(out)
@@ -437,7 +460,7 @@ func GetMultipathDevices() (multipathDevices []model.MultipathDevice, err error)
 			multipathDevices = append(multipathDevices, mapItem)
 		}
 	}
-	log.Infof("Found %d multipath devices (%d unhealthy, %d orphan)", len(multipathDevices), unhealthyDeviceCount, orphanDeviceCount)
+	log.Infof("Found %d multipath devices (%d unhealthy, of which %d are orphan)", len(multipathDevices), unhealthyDeviceCount, orphanDeviceCount)
 	return multipathDevices, nil
 }
 

--- a/tunelinux/multipath.go
+++ b/tunelinux/multipath.go
@@ -23,9 +23,8 @@ import (
 )
 
 const (
-	multipath                  = "multipath"
-	multipathTimeoutMaxTries   = 3
-	multipathTimeoutRetrySleep = 2 * time.Second
+	multipath                = "multipath"
+	multipathTimeoutMaxTries = 3
 
 	// uxsockTimeoutParam is the multipath.conf defaults-section key that controls
 	// the unix domain socket timeout (in milliseconds) used by multipathd.
@@ -53,6 +52,12 @@ var (
 	staleDeviceRemovalMutex sync.Mutex
 	readProcMountsMutex     sync.Mutex
 	ErrMultipathTimeout     = errors.New("multipathd timeout")
+
+	// multipathTimeoutRetrySleep is a var so tests can shorten retry delays.
+	multipathTimeoutRetrySleep = 2 * time.Second
+
+	// execCommandOutput lets tests exercise retry behavior without shelling out.
+	execCommandOutput = util.ExecCommandOutput
 )
 
 // GetMultipathConfigFile returns path of the template multipath.conf file according to OS distro
@@ -391,12 +396,12 @@ func GetMultipathDevices() (multipathDevices []model.MultipathDevice, err error)
 	defer log.Trace("<<<<< getMultipathDevices")
 
 	for try := 1; try <= multipathTimeoutMaxTries; try++ {
-		out, _, cmdErr := util.ExecCommandOutput("multipathd", []string{"show", "multipaths", "json"})
+		out, _, cmdErr := execCommandOutput("multipathd", []string{"show", "multipaths", "json"})
 
 		multipathDevices, err = parseMultipathDevices(out)
-		if errors.Is(err, ErrMultipathTimeout) {
+		if errors.Is(err, ErrMultipathTimeout) || (cmdErr != nil && linux.IsMultipathTimeoutError(cmdErr.Error())) {
 			if try == multipathTimeoutMaxTries {
-				return nil, fmt.Errorf("failed to get the multipath devices after %d attempts: %w", multipathTimeoutMaxTries, err)
+				return nil, fmt.Errorf("failed to get the multipath devices after %d attempts: %w", multipathTimeoutMaxTries, ErrMultipathTimeout)
 			}
 			log.Warnf("Transient multipathd timeout while getting multipath devices; retrying attempt %d of %d", try+1, multipathTimeoutMaxTries)
 			time.Sleep(multipathTimeoutRetrySleep)
@@ -411,10 +416,6 @@ func GetMultipathDevices() (multipathDevices []model.MultipathDevice, err error)
 }
 
 func parseMultipathDevices(out string) (multipathDevices []model.MultipathDevice, err error) {
-	if linux.IsMultipathTimeoutError(out) {
-		return nil, ErrMultipathTimeout
-	}
-
 	out = strings.TrimSpace(out)
 	if out == "" {
 		log.Infof("No multipath devices found")
@@ -425,6 +426,9 @@ func parseMultipathDevices(out string) (multipathDevices []model.MultipathDevice
 	decoder := json.NewDecoder(strings.NewReader(out))
 	err = decoder.Decode(multipathJson)
 	if err != nil {
+		if linux.IsMultipathTimeoutError(out) {
+			return nil, ErrMultipathTimeout
+		}
 		return nil, fmt.Errorf("Invalid JSON output of multipathd command: %s", err.Error())
 	}
 	var extra interface{}

--- a/tunelinux/multipath.go
+++ b/tunelinux/multipath.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -222,7 +221,7 @@ func GetMultipathRecommendations() (settings []DeviceRecommendation, err error) 
 			return deviceRecommendations, err
 		}
 		// Obtain contents of /etc/multipath.conf
-		content, err := ioutil.ReadFile(linux.MultipathConf)
+		content, err := os.ReadFile(linux.MultipathConf)
 		if err != nil {
 			log.Error(err.Error())
 			return nil, err

--- a/tunelinux/multipath.go
+++ b/tunelinux/multipath.go
@@ -410,7 +410,10 @@ func GetMultipathDevices() (multipathDevices []model.MultipathDevice, err error)
 		if cmdErr != nil {
 			return nil, fmt.Errorf("failed to get the multipath devices due to the error: %s", cmdErr.Error())
 		}
-		return multipathDevices, err
+		if err != nil {
+			return nil, err
+		}
+		return multipathDevices, nil
 	}
 	return nil, ErrMultipathTimeout
 }

--- a/tunelinux/multipath_test.go
+++ b/tunelinux/multipath_test.go
@@ -1,0 +1,105 @@
+package tunelinux
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParseMultipathDevices(t *testing.T) {
+	tests := []struct {
+		name    string
+		out     string
+		wantLen int
+		wantErr error
+	}{
+		{
+			name: "empty output",
+			out:  "",
+		},
+		{
+			name: "whitespace output",
+			out:  " \n\t ",
+		},
+		{
+			name:    "timeout output",
+			out:     "timeout",
+			wantErr: ErrMultipathTimeout,
+		},
+		{
+			name:    "receiving packet output",
+			out:     "multipathd: receiving packet failed",
+			wantErr: ErrMultipathTimeout,
+		},
+		{
+			name:    "invalid JSON",
+			out:     "{not-json}",
+			wantErr: errAny,
+		},
+		{
+			name:    "trailing JSON garbage",
+			out:     `{"maps":[]} trailing`,
+			wantErr: errAny,
+		},
+		{
+			name: "valid no maps",
+			out:  `{"maps":[]}`,
+		},
+		{
+			name: "valid devices",
+			out: `{
+				"maps": [
+					{"name":"healthy","vend":"Nimble","paths":2},
+					{"name":"unhealthy","vend":"Nimble","paths":0,"path_faults":1},
+					{"name":"orphan","queueing":"off","features":"0"},
+					{"name":"unsupported","vend":"Other","paths":2}
+				]
+			}`,
+			wantLen: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			devices, err := parseMultipathDevices(tt.out)
+			if tt.wantErr == nil && err != nil {
+				t.Fatalf("parseMultipathDevices() error = %v, want nil", err)
+			}
+			if tt.wantErr == errAny && err == nil {
+				t.Fatalf("parseMultipathDevices() error = nil, want error")
+			}
+			if tt.wantErr != nil && tt.wantErr != errAny && !errors.Is(err, tt.wantErr) {
+				t.Fatalf("parseMultipathDevices() error = %v, want %v", err, tt.wantErr)
+			}
+			if len(devices) != tt.wantLen {
+				t.Fatalf("parseMultipathDevices() returned %d devices, want %d", len(devices), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestParseMultipathDevicesClassifiesUnhealthyAndOrphan(t *testing.T) {
+	devices, err := parseMultipathDevices(`{
+		"maps": [
+			{"name":"healthy","vend":"Nimble","paths":2},
+			{"name":"unhealthy","vend":"Nimble","paths":0,"path_faults":1},
+			{"name":"orphan","queueing":"off","features":"0"}
+		]
+	}`)
+	if err != nil {
+		t.Fatalf("parseMultipathDevices() error = %v, want nil", err)
+	}
+	if len(devices) != 3 {
+		t.Fatalf("parseMultipathDevices() returned %d devices, want 3", len(devices))
+	}
+	if devices[0].IsUnhealthy {
+		t.Fatalf("device %q IsUnhealthy = true, want false", devices[0].Name)
+	}
+	if !devices[1].IsUnhealthy {
+		t.Fatalf("device %q IsUnhealthy = false, want true", devices[1].Name)
+	}
+	if !devices[2].IsUnhealthy {
+		t.Fatalf("device %q IsUnhealthy = false, want true", devices[2].Name)
+	}
+}
+
+var errAny = errors.New("any error")

--- a/tunelinux/multipath_test.go
+++ b/tunelinux/multipath_test.go
@@ -2,6 +2,7 @@ package tunelinux
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 )
 
@@ -103,3 +104,129 @@ func TestParseMultipathDevicesClassifiesUnhealthyAndOrphan(t *testing.T) {
 }
 
 var errAny = errors.New("any error")
+
+func TestParseMultipathDevicesValidJSONWithQTimeoutsNotTimeout(t *testing.T) {
+	out := `{
+		"major_version": 0,
+		"minor_version": 1,
+		"maps": [{
+			"name": "mpatha",
+			"uuid": "360002ac00000000000005d8d0002b114",
+			"sysfs": "dm-2",
+			"queueing": "18 chk",
+			"paths": 2,
+			"features": "1 queue_if_no_path",
+			"path_faults": 0,
+			"vend": "3PARdata",
+			"total_q_time": 0,
+			"q_timeouts": 0,
+			"path_groups": [{"paths": [{"dev": "sdb"}, {"dev": "sdd"}]}]
+		}]
+	}`
+	devices, err := parseMultipathDevices(out)
+	if errors.Is(err, ErrMultipathTimeout) {
+		t.Fatalf("parseMultipathDevices() misclassified valid JSON as ErrMultipathTimeout")
+	}
+	if err != nil {
+		t.Fatalf("parseMultipathDevices() error = %v, want nil", err)
+	}
+	if len(devices) != 1 {
+		t.Fatalf("parseMultipathDevices() returned %d devices, want 1", len(devices))
+	}
+	if devices[0].Name != "mpatha" {
+		t.Fatalf("parseMultipathDevices() device name = %q, want %q", devices[0].Name, "mpatha")
+	}
+}
+
+func withStubbedExec(t *testing.T, fn func(cmd string, args []string) (string, int, error)) {
+	t.Helper()
+	origExec := execCommandOutput
+	origSleep := multipathTimeoutRetrySleep
+	execCommandOutput = fn
+	multipathTimeoutRetrySleep = 0
+	t.Cleanup(func() {
+		execCommandOutput = origExec
+		multipathTimeoutRetrySleep = origSleep
+	})
+}
+
+var errExecTimeout = fmt.Errorf("command multipathd killed as timeout of 60 seconds reached")
+
+func TestGetMultipathDevicesRetriesOnExecTimeout(t *testing.T) {
+	calls := 0
+	withStubbedExec(t, func(cmd string, args []string) (string, int, error) {
+		calls++
+		if calls < multipathTimeoutMaxTries {
+			return "", 888, errExecTimeout
+		}
+		return `{"maps":[{"name":"healthy","vend":"Nimble","paths":2}]}`, 0, nil
+	})
+
+	devices, err := GetMultipathDevices()
+	if err != nil {
+		t.Fatalf("GetMultipathDevices() error = %v, want nil", err)
+	}
+	if calls != multipathTimeoutMaxTries {
+		t.Fatalf("execCommandOutput called %d times, want %d", calls, multipathTimeoutMaxTries)
+	}
+	if len(devices) != 1 {
+		t.Fatalf("GetMultipathDevices() returned %d devices, want 1", len(devices))
+	}
+}
+
+func TestGetMultipathDevicesExhaustsRetriesOnExecTimeout(t *testing.T) {
+	calls := 0
+	withStubbedExec(t, func(cmd string, args []string) (string, int, error) {
+		calls++
+		return "", 888, errExecTimeout
+	})
+
+	devices, err := GetMultipathDevices()
+	if !errors.Is(err, ErrMultipathTimeout) {
+		t.Fatalf("GetMultipathDevices() error = %v, want ErrMultipathTimeout", err)
+	}
+	if devices != nil {
+		t.Fatalf("GetMultipathDevices() devices = %v, want nil", devices)
+	}
+	if calls != multipathTimeoutMaxTries {
+		t.Fatalf("execCommandOutput called %d times, want %d", calls, multipathTimeoutMaxTries)
+	}
+}
+
+func TestGetMultipathDevicesDoesNotRetryOnNonTimeoutError(t *testing.T) {
+	calls := 0
+	withStubbedExec(t, func(cmd string, args []string) (string, int, error) {
+		calls++
+		return "", 1, fmt.Errorf("multipathd: command not found")
+	})
+
+	_, err := GetMultipathDevices()
+	if err == nil {
+		t.Fatal("GetMultipathDevices() error = nil, want error")
+	}
+	if errors.Is(err, ErrMultipathTimeout) {
+		t.Fatalf("GetMultipathDevices() error = %v, want non-timeout error", err)
+	}
+	if calls != 1 {
+		t.Fatalf("execCommandOutput called %d times, want 1", calls)
+	}
+}
+
+func TestGetMultipathDevicesValidJSONWithQTimeoutsNoRetry(t *testing.T) {
+	calls := 0
+	withStubbedExec(t, func(cmd string, args []string) (string, int, error) {
+		calls++
+		return `{"maps":[{"name":"mpatha","vend":"3PARdata","paths":2,"q_timeouts":0,"total_q_time":0}]}`, 0, nil
+	})
+
+	devices, err := GetMultipathDevices()
+	if err != nil {
+		t.Fatalf("GetMultipathDevices() error = %v, want nil", err)
+	}
+	if calls != 1 {
+		t.Fatalf("execCommandOutput called %d times, want 1", calls)
+	}
+	if len(devices) != 1 {
+		t.Fatalf("GetMultipathDevices() returned %d devices, want 1", len(devices))
+	}
+}


### PR DESCRIPTION
To optimize memory usage in the GetMultipathDevices function, the following changes were implemented:

1) Directly unmarshaled the output string without converting it to a byte slice.

2) Instead of logging the entire multipathDevices, logged only the counts: the length of multipathDevices, unhealthyDeviceCount, and orphanDeviceCount.

Design Document: https://confluence.storage.hpecorp.net/spaces/ESI/pages/682047152/CON-4772+-+Fix+hpe-csi-node+OOM+kill+issue 


This also contains a fix for the Jira https://jira.storage.hpecorp.net/browse/CON-3096 

