### PR TITLE
Log warning on nguid read failure

### DIFF
--- a/linux/device.go
+++ b/linux/device.go
@@ -1707,7 +1707,8 @@ func GetNvmeDeviceFromNamespace(serialOrNamespace string) (*model.Device, error)
             log.Tracef("serial path=%s", sysfsSerialPath)
             serial, err := util.FileReadFirstLine(sysfsSerialPath)
             if err != nil {
-				return nil, err
+				log.Warnf("Failed to read nguid from %s: %v", sysfsSerialPath, err)
+				continue
 			}
             // Normalize the serial from sysfs by removing dashes and whitespace
 	    // In nomarlizeSerial we remove "-" from serial 


### PR DESCRIPTION
Log a warning when failing to read nguid from sysfs path instead of returning an error. A missing NGUID on one NVMe namespace should not terminate device discovery.