### PR TITLE
CON-4777: fix csi node init crash on restart

### DIFF
--- a/linux/device.go
+++ b/linux/device.go
@@ -876,6 +876,7 @@ func getFcTargetWwpns(volume *model.Volume) []string {
 
 // find if an existing lun has been remapped with new lun provided
 // if found, remove old paths and rescan new lun paths
+//
 //nolint:gocyclo
 func handleRemappedLun(volume *model.Volume) (err error) {
 	log.Tracef(">>> handleRemappedLun called with volume %s serial %s lun %s", volume.Name, volume.SerialNumber, volume.LunID)
@@ -1559,7 +1560,7 @@ func RescanForCapacityUpdates(devicePath string) error {
 		devicePath = strings.TrimPrefix(devicePath, "/dev/mapper/")
 		// reload multipath map to apply new size
 		args = []string{"resize", "map", devicePath}
-		out, _, err := util.ExecCommandOutput("multipathd", args)
+		out, _, err := multipathdExecCommandOutput("multipathd", args, MultipathdCommandTimeout())
 		if err != nil {
 			return err
 		}

--- a/linux/device.go
+++ b/linux/device.go
@@ -1422,7 +1422,7 @@ func DeleteDevice(dev *model.Device) (err error) {
 // flush the device buffers
 func flushbufs(dev *model.Device) error {
 	log.Tracef("flushbufs called for %+v", dev)
-	if dev == nil && dev.AltFullPathName == "" {
+	if dev == nil || dev.AltFullPathName == "" {
 		return fmt.Errorf("device.AltFullPathName %+v not present to perform flushbufs", dev)
 	}
 	args := []string{"--flushbufs", dev.AltFullPathName}

--- a/linux/multipath.go
+++ b/linux/multipath.go
@@ -5,8 +5,10 @@ package linux
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -29,14 +31,59 @@ const (
 	// MultipathConf configuration file for multipathd
 	MultipathConf = "/etc/multipath.conf"
 	// MultipathBindings bindings file for multipathd
-	MultipathBindings  = "/etc/multipath/bindings"
+	MultipathBindings = "/etc/multipath/bindings"
 	// orphanPathsPattern captures WWID (first field from multipathd show paths output)
 	// along with H:C:T:L so that orphan paths can be scoped to a specific volume.
 	// multipathd show paths format: %w %d %t %i %o %T %z %s %m
 	//   %w = WWID, %i = hcil (H:C:T:L)
 	orphanPathsPattern = "(?P<wwid>\\S+)\\s+\\S+\\s+\\S+\\s+(?P<host>\\d+):(?P<channel>\\d+):(?P<target>\\d+):(?P<lun>\\d+).*(REPLACE_VENDOR).*orphan"
 	maxTries           = 3
+
+	multipathUxsockTimeoutEnvVar         = "MULTIPATH_UXSOCK_TIMEOUT"
+	defaultMultipathUxsockTimeoutMillis  = 300000
+	multipathCommandTimeoutMarginSeconds = 5
 )
+
+var (
+	multipathdUxsockTimeout, multipathdCommandTimeout = loadMultipathdTimeouts()
+	multipathdExecCommandOutput                       = util.ExecCommandOutputWithTimeout
+)
+
+// MultipathdUxsockTimeout returns the multipathd uxsock timeout, in
+// milliseconds, calculated when the package is initialized.
+func MultipathdUxsockTimeout() int {
+	return multipathdUxsockTimeout
+}
+
+// MultipathdCommandTimeout returns the multipathd executor timeout calculated
+// when the package is initialized.
+func MultipathdCommandTimeout() int {
+	return multipathdCommandTimeout
+}
+
+// loadMultipathdTimeouts returns the configured uxsock timeout and an executor
+// timeout that exceeds it by a fixed margin. MULTIPATH_UXSOCK_TIMEOUT is
+// expressed in milliseconds; invalid values use the recommended 300 seconds.
+func loadMultipathdTimeouts() (int, int) {
+	uxsockTimeoutMillis := defaultMultipathUxsockTimeoutMillis
+	if value := os.Getenv(multipathUxsockTimeoutEnvVar); value != "" {
+		parsed, err := strconv.Atoi(value)
+		if err != nil || parsed <= 0 {
+			log.Warnf("Invalid value %q for %s (must be a positive integer), using default value of %d milliseconds",
+				value, multipathUxsockTimeoutEnvVar, defaultMultipathUxsockTimeoutMillis)
+		} else {
+			uxsockTimeoutMillis = parsed
+		}
+	}
+
+	// Round up partial seconds so the executor timeout always exceeds uxsock_timeout.
+	// If uxsock_timeout is 300999 milliseconds, the executor timeout will be 306 seconds.
+	uxsockTimeoutSeconds := uxsockTimeoutMillis / 1000
+	if uxsockTimeoutMillis%1000 != 0 {
+		uxsockTimeoutSeconds++
+	}
+	return uxsockTimeoutMillis, uxsockTimeoutSeconds + multipathCommandTimeoutMarginSeconds
+}
 
 func getOrphanPathsPattern() string {
 	vendorPattern := strings.Join(DeviceVendorPatterns, "|")
@@ -69,7 +116,7 @@ func MultipathdReconfigure() (out string, err error) {
 
 	var args []string
 	args = []string{"reconfigure"}
-	out, _, err = util.ExecCommandOutput(multipathd, args)
+	out, _, err = multipathdExecCommandOutput(multipathd, args, MultipathdCommandTimeout())
 	if err != nil {
 		log.Error("unable to reconfigure multipathd settings", err.Error())
 		err = fmt.Errorf("unable to reconfigure multipathd settings, Error: %s %s", err.Error(), out)
@@ -88,7 +135,7 @@ func multipathShowCmdOrphanPaths() (output []string, err error) {
 	multipathMutex.Lock()
 	defer multipathMutex.Unlock()
 
-	out, _, err := util.ExecCommandOutput(multipathd, showPathsFormat)
+	out, _, err := multipathdExecCommandOutput(multipathd, showPathsFormat, MultipathdCommandTimeout())
 	if err != nil {
 		log.Warnf("multipathdShowCmd: error %v with args %v", err, showPathsFormat)
 		return nil, err
@@ -108,7 +155,7 @@ func multipathdShowCmd(args []string, serialNumber string) (output []string, err
 	multipathMutex.Lock()
 	defer multipathMutex.Unlock()
 
-	out, _, err := util.ExecCommandOutput(multipathd, args)
+	out, _, err := multipathdExecCommandOutput(multipathd, args, MultipathdCommandTimeout())
 	if err != nil {
 		log.Warnf("multipathdShowCmd: error %v with args %v", err, args)
 		return nil, err

--- a/linux/multipath.go
+++ b/linux/multipath.go
@@ -82,7 +82,10 @@ func loadMultipathdTimeouts() (int, int) {
 	if uxsockTimeoutMillis%1000 != 0 {
 		uxsockTimeoutSeconds++
 	}
-	return uxsockTimeoutMillis, uxsockTimeoutSeconds + multipathCommandTimeoutMarginSeconds
+	multipathCommandTimeout := uxsockTimeoutSeconds + multipathCommandTimeoutMarginSeconds
+	log.Infof("Using multipathd uxsock timeout of %d milliseconds and executor timeout of %d seconds",
+		uxsockTimeoutMillis, multipathCommandTimeout)
+	return uxsockTimeoutMillis, multipathCommandTimeout
 }
 
 func getOrphanPathsPattern() string {

--- a/linux/multipath_test.go
+++ b/linux/multipath_test.go
@@ -2,6 +2,7 @@
 package linux
 
 import (
+	"os"
 	"regexp"
 	"testing"
 
@@ -84,6 +85,54 @@ func TestMatchesWWID(t *testing.T) {
 	}
 }
 
+func TestLoadMultipathdTimeouts(t *testing.T) {
+	tests := []struct {
+		name               string
+		value              string
+		wantUxsockTimeout  int
+		wantCommandTimeout int
+	}{
+		{name: "default", wantUxsockTimeout: 300000, wantCommandTimeout: 305},
+		{name: "configured", value: "60000", wantUxsockTimeout: 60000, wantCommandTimeout: 65},
+		{name: "rounds partial second up", value: "60001", wantUxsockTimeout: 60001, wantCommandTimeout: 66},
+		{name: "zero falls back", value: "0", wantUxsockTimeout: 300000, wantCommandTimeout: 305},
+		{name: "negative falls back", value: "-1", wantUxsockTimeout: 300000, wantCommandTimeout: 305},
+		{name: "invalid falls back", value: "invalid", wantUxsockTimeout: 300000, wantCommandTimeout: 305},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv(multipathUxsockTimeoutEnvVar, test.value)
+			if test.name == "default" {
+				if err := os.Unsetenv(multipathUxsockTimeoutEnvVar); err != nil {
+					t.Fatalf("unset %s: %v", multipathUxsockTimeoutEnvVar, err)
+				}
+			}
+
+			gotUxsockTimeout, gotCommandTimeout := loadMultipathdTimeouts()
+			if gotUxsockTimeout != test.wantUxsockTimeout {
+				t.Fatalf("loadMultipathdTimeouts() uxsock timeout = %d, want %d", gotUxsockTimeout, test.wantUxsockTimeout)
+			}
+			if gotCommandTimeout != test.wantCommandTimeout {
+				t.Fatalf("loadMultipathdTimeouts() command timeout = %d, want %d", gotCommandTimeout, test.wantCommandTimeout)
+			}
+		})
+	}
+}
+
+func TestMultipathdCommandTimeoutIsCached(t *testing.T) {
+	wantUxsockTimeout := MultipathdUxsockTimeout()
+	wantCommandTimeout := MultipathdCommandTimeout()
+	t.Setenv(multipathUxsockTimeoutEnvVar, "1")
+
+	if got := MultipathdUxsockTimeout(); got != wantUxsockTimeout {
+		t.Fatalf("MultipathdUxsockTimeout() = %d after environment change, want cached value %d", got, wantUxsockTimeout)
+	}
+	if got := MultipathdCommandTimeout(); got != wantCommandTimeout {
+		t.Fatalf("MultipathdCommandTimeout() = %d after environment change, want cached value %d", got, wantCommandTimeout)
+	}
+}
+
 // ---- orphanPathsPattern regex tests ----
 
 // Simulated multipathd show paths lines in format: %w %d %t %i %o %T %z %s %m
@@ -118,14 +167,14 @@ var orphanRegexTests = []struct {
 		wantLun:    "3",
 	},
 	{
-		name:       "non-orphan path: belongs to mpathcd",
-		line:       "360002ac0000000000200d34e0007f544 sdh active 33:0:0:1 running ready tur 3PARdata,VV mpathcd",
-		wantMatch:  false,
+		name:      "non-orphan path: belongs to mpathcd",
+		line:      "360002ac0000000000200d34e0007f544 sdh active 33:0:0:1 running ready tur 3PARdata,VV mpathcd",
+		wantMatch: false,
 	},
 	{
-		name:       "unknown vendor: should not match",
-		line:       "360002ac0000000000200d34e0007f544 sdc active 33:0:0:1 running ready tur UNKNOWN,VV [orphan]",
-		wantMatch:  false,
+		name:      "unknown vendor: should not match",
+		line:      "360002ac0000000000200d34e0007f544 sdc active 33:0:0:1 running ready tur UNKNOWN,VV [orphan]",
+		wantMatch: false,
 	},
 	{
 		name:       "TrueNAS orphan path",
@@ -195,11 +244,11 @@ func filterOrphanLines(lines []string, serialNumber, lunID string) []string {
 }
 
 var orphanFilterTests = []struct {
-	name       string
-	lines      []string
-	serial     string
-	lunID      string
-	wantHCTLs  []string
+	name      string
+	lines     []string
+	serial    string
+	lunID     string
+	wantHCTLs []string
 }{
 	{
 		name: "array1 serial matches only array1 orphans at same LUN",

--- a/mpathconfig/configresource.go
+++ b/mpathconfig/configresource.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -121,8 +122,14 @@ func (section *Section) PrintSection(indent int) (conf []string) {
 		}
 	}
 	spacerSize++
-	for property, value := range section.properties {
-		formattedProperty = fmt.Sprintf("%s    %-"+strconv.Itoa(spacerSize)+"s%s%s", indenter, property, value, NEWLINE)
+	// sort keys so the emitted output is deterministic across restarts (Go randomizes map iteration order)
+	sortedKeys := make([]string, 0, len(section.properties))
+	for property := range section.properties {
+		sortedKeys = append(sortedKeys, property)
+	}
+	sort.Strings(sortedKeys)
+	for _, property := range sortedKeys {
+		formattedProperty = fmt.Sprintf("%s    %-"+strconv.Itoa(spacerSize)+"s%s%s", indenter, property, section.properties[property], NEWLINE)
 		conf = append(conf, formattedProperty)
 	}
 	// handle duplicate param case in defaults/alias/multipaths section
@@ -238,7 +245,7 @@ func addOption(section *Section, option string) {
 	}
 }
 
-//checks for the section
+// checks for the section
 func isSection(line string) (bool, error) {
 	line = strings.TrimSpace(line)
 	prefixes := []string{"defaults", "blacklist", "blacklist_exceptions", "devices", "device", "multipaths", "multipath"}

--- a/tunelinux/multipath.go
+++ b/tunelinux/multipath.go
@@ -3,12 +3,14 @@ package tunelinux
 // Copyright 2019 Hewlett Packard Enterprise Development LP.
 import (
 	"bufio"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -20,6 +22,7 @@ import (
 	"github.com/hpe-storage/common-host-libs/model"
 	"github.com/hpe-storage/common-host-libs/mpathconfig"
 	"github.com/hpe-storage/common-host-libs/util"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -37,6 +40,8 @@ const (
 	// uxsockTimeoutEnvVar, when set to a valid positive integer, overrides
 	// uxsockTimeoutRecommended so deployments can tune the value without a code change.
 	uxsockTimeoutEnvVar = "MULTIPATH_UXSOCK_TIMEOUT"
+
+	multipathAppliedConfigHashPath = "/host/run/hpe-storage/multipath-config.sha256"
 
 	// multipath params
 	multipathParamPattern = "\\s*(?P<name>.*?)\\s+(?P<value>.*)"
@@ -325,6 +330,69 @@ func setMultipathRecommendations(recommendations []*Recommendation, device strin
 	return nil
 }
 
+func reconfigureMultipathdIfConfigNotApplied(configPath string, appliedHashPath string, reconfigure func() (string, error)) error {
+	config, err := os.ReadFile(configPath)
+	if err != nil {
+		return err
+	}
+
+	stateDir := filepath.Dir(appliedHashPath)
+	if err = os.MkdirAll(stateDir, 0755); err != nil {
+		return err
+	}
+	lock, err := os.OpenFile(appliedHashPath+".lock", os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return err
+	}
+	defer lock.Close()
+	if err = unix.Flock(int(lock.Fd()), unix.LOCK_EX); err != nil {
+		return err
+	}
+	defer unix.Flock(int(lock.Fd()), unix.LOCK_UN)
+
+	currentHash := fmt.Sprintf("%x", sha256.Sum256(config))
+	appliedHash, err := os.ReadFile(appliedHashPath)
+	if err == nil && strings.TrimSpace(string(appliedHash)) == currentHash {
+		log.Info("Skipped multipathd reconfigure because the current multipath.conf settings are already applied")
+		return nil
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	_, err = reconfigure()
+	if err != nil {
+		return err
+	}
+	if err = writeAppliedConfigHash(appliedHashPath, currentHash); err != nil {
+		return err
+	}
+	log.Info("Successfully configured multipath.conf settings")
+	return nil
+}
+
+func writeAppliedConfigHash(filePath string, hash string) error {
+	tempFile, err := os.CreateTemp(filepath.Dir(filePath), ".multipath-config-*.tmp")
+	if err != nil {
+		return err
+	}
+	tempPath := tempFile.Name()
+	defer os.Remove(tempPath)
+
+	if _, err = tempFile.WriteString(hash + "\n"); err != nil {
+		tempFile.Close()
+		return err
+	}
+	if err = tempFile.Sync(); err != nil {
+		tempFile.Close()
+		return err
+	}
+	if err = tempFile.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tempPath, filePath)
+}
+
 // SetMultipathRecommendations sets multipath.conf settings
 func SetMultipathRecommendations() (err error) {
 	log.Traceln(">>>>> SetMultipathRecommendations")
@@ -367,13 +435,7 @@ func SetMultipathRecommendations() (err error) {
 		return err
 	}
 
-	// Reconfigure settings in any case to make sure new settings are applied
-	_, err = linux.MultipathdReconfigure()
-	if err != nil {
-		return err
-	}
-	log.Info("Successfully configured multipath.conf settings")
-	return nil
+	return reconfigureMultipathdIfConfigNotApplied(linux.MultipathConf, multipathAppliedConfigHashPath, linux.MultipathdReconfigure)
 }
 
 // ConfigureMultipath ensures following

--- a/tunelinux/multipath.go
+++ b/tunelinux/multipath.go
@@ -15,7 +15,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/hpe-storage/common-host-libs/linux"
 	log "github.com/hpe-storage/common-host-libs/logger"
@@ -26,8 +25,7 @@ import (
 )
 
 const (
-	multipath                = "multipath"
-	multipathTimeoutMaxTries = 3
+	multipath = "multipath"
 
 	// uxsockTimeoutParam is the multipath.conf defaults-section key that controls
 	// the unix domain socket timeout (in milliseconds) used by multipathd.
@@ -50,10 +48,7 @@ var (
 	readProcMountsMutex     sync.Mutex
 	ErrMultipathTimeout     = errors.New("multipathd timeout")
 
-	// multipathTimeoutRetrySleep is a var so tests can shorten retry delays.
-	multipathTimeoutRetrySleep = 2 * time.Second
-
-	// execCommandOutput lets tests exercise retry behavior without shelling out.
+	// execCommandOutput lets tests exercise command behavior without shelling out.
 	execCommandOutput = util.ExecCommandOutputWithTimeout
 )
 
@@ -445,31 +440,27 @@ func ConfigureMultipath() (err error) {
 	return nil
 }
 
+// GetMultipathDevices queries multipathd for the current multipath devices and
+// returns the supported and residual (orphan) devices parsed from its JSON
+// output. A transient multipathd timeout is reported as ErrMultipathTimeout so
+// callers can skip the cycle instead of treating it as a hard failure.
 func GetMultipathDevices() (multipathDevices []model.MultipathDevice, err error) {
 	log.Tracef(">>>> getMultipathDevices ")
 	defer log.Trace("<<<<< getMultipathDevices")
 
-	for try := 1; try <= multipathTimeoutMaxTries; try++ {
-		out, _, cmdErr := execCommandOutput("multipathd", []string{"show", "multipaths", "json"}, linux.MultipathdCommandTimeout())
+	out, _, cmdErr := execCommandOutput("multipathd", []string{"show", "multipaths", "json"}, linux.MultipathdCommandTimeout())
 
-		multipathDevices, err = parseMultipathDevices(out)
-		if errors.Is(err, ErrMultipathTimeout) || (cmdErr != nil && linux.IsMultipathTimeoutError(cmdErr.Error())) {
-			if try == multipathTimeoutMaxTries {
-				return nil, fmt.Errorf("failed to get the multipath devices after %d attempts: %w", multipathTimeoutMaxTries, ErrMultipathTimeout)
-			}
-			log.Warnf("Transient multipathd timeout while getting multipath devices; retrying attempt %d of %d", try+1, multipathTimeoutMaxTries)
-			time.Sleep(multipathTimeoutRetrySleep)
-			continue
-		}
-		if cmdErr != nil {
-			return nil, fmt.Errorf("failed to get the multipath devices due to the error: %s", cmdErr.Error())
-		}
-		if err != nil {
-			return nil, err
-		}
-		return multipathDevices, nil
+	multipathDevices, err = parseMultipathDevices(out)
+	if errors.Is(err, ErrMultipathTimeout) || (cmdErr != nil && linux.IsMultipathTimeoutError(cmdErr.Error())) {
+		return nil, ErrMultipathTimeout
 	}
-	return nil, ErrMultipathTimeout
+	if cmdErr != nil {
+		return nil, fmt.Errorf("failed to get the multipath devices due to the error: %s", cmdErr.Error())
+	}
+	if err != nil {
+		return nil, err
+	}
+	return multipathDevices, nil
 }
 
 func parseMultipathDevices(out string) (multipathDevices []model.MultipathDevice, err error) {

--- a/tunelinux/multipath.go
+++ b/tunelinux/multipath.go
@@ -33,14 +33,6 @@ const (
 	// the unix domain socket timeout (in milliseconds) used by multipathd.
 	uxsockTimeoutParam = "uxsock_timeout"
 
-	// uxsockTimeoutRecommended is the default recommended value for uxsock_timeout. Keep
-	// this in sync with the value shipped in the multipath.conf.generic/upstream templates.
-	uxsockTimeoutRecommended = "300000"
-
-	// uxsockTimeoutEnvVar, when set to a valid positive integer, overrides
-	// uxsockTimeoutRecommended so deployments can tune the value without a code change.
-	uxsockTimeoutEnvVar = "MULTIPATH_UXSOCK_TIMEOUT"
-
 	multipathAppliedConfigHashPath = "/host/run/hpe-storage/multipath-config.sha256"
 
 	// multipath params
@@ -62,7 +54,7 @@ var (
 	multipathTimeoutRetrySleep = 2 * time.Second
 
 	// execCommandOutput lets tests exercise retry behavior without shelling out.
-	execCommandOutput = util.ExecCommandOutput
+	execCommandOutput = util.ExecCommandOutputWithTimeout
 )
 
 // GetMultipathConfigFile returns path of the template multipath.conf file according to OS distro
@@ -458,7 +450,7 @@ func GetMultipathDevices() (multipathDevices []model.MultipathDevice, err error)
 	defer log.Trace("<<<<< getMultipathDevices")
 
 	for try := 1; try <= multipathTimeoutMaxTries; try++ {
-		out, _, cmdErr := execCommandOutput("multipathd", []string{"show", "multipaths", "json"})
+		out, _, cmdErr := execCommandOutput("multipathd", []string{"show", "multipaths", "json"}, linux.MultipathdCommandTimeout())
 
 		multipathDevices, err = parseMultipathDevices(out)
 		if errors.Is(err, ErrMultipathTimeout) || (cmdErr != nil && linux.IsMultipathTimeoutError(cmdErr.Error())) {
@@ -730,18 +722,8 @@ func forceDeleteMultipathDevice(multipathDevice string) error {
 	return nil
 }
 
-// getUxsockTimeoutValue returns the uxsock_timeout value to apply to /etc/multipath.conf.
-// If the MULTIPATH_UXSOCK_TIMEOUT environment variable is set to a valid positive integer,
-// that value takes precedence; otherwise uxsockTimeoutRecommended is used.
+// getUxsockTimeoutValue returns the cached uxsock_timeout value to apply to
+// /etc/multipath.conf.
 func getUxsockTimeoutValue() string {
-	envValue := os.Getenv(uxsockTimeoutEnvVar)
-	if envValue == "" {
-		return uxsockTimeoutRecommended
-	}
-	if parsed, err := strconv.Atoi(envValue); err != nil || parsed <= 0 {
-		log.Warnf("Invalid value %q for env var %s (must be a positive integer), falling back to default %s",
-			envValue, uxsockTimeoutEnvVar, uxsockTimeoutRecommended)
-		return uxsockTimeoutRecommended
-	}
-	return envValue
+	return strconv.Itoa(linux.MultipathdUxsockTimeout())
 }

--- a/tunelinux/multipath_test.go
+++ b/tunelinux/multipath_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/hpe-storage/common-host-libs/linux"
 )
 
 func TestReconfigureMultipathdIfConfigNotApplied(t *testing.T) {
@@ -217,7 +219,7 @@ func TestParseMultipathDevicesValidJSONWithQTimeoutsNotTimeout(t *testing.T) {
 	}
 }
 
-func withStubbedExec(t *testing.T, fn func(cmd string, args []string) (string, int, error)) {
+func withStubbedExec(t *testing.T, fn func(cmd string, args []string, timeout int) (string, int, error)) {
 	t.Helper()
 	origExec := execCommandOutput
 	origSleep := multipathTimeoutRetrySleep
@@ -233,8 +235,11 @@ var errExecTimeout = fmt.Errorf("command multipathd killed as timeout of 60 seco
 
 func TestGetMultipathDevicesRetriesOnExecTimeout(t *testing.T) {
 	calls := 0
-	withStubbedExec(t, func(cmd string, args []string) (string, int, error) {
+	withStubbedExec(t, func(cmd string, args []string, timeout int) (string, int, error) {
 		calls++
+		if timeout != linux.MultipathdCommandTimeout() {
+			t.Fatalf("timeout = %d, want %d", timeout, linux.MultipathdCommandTimeout())
+		}
 		if calls < multipathTimeoutMaxTries {
 			return "", 888, errExecTimeout
 		}
@@ -255,7 +260,7 @@ func TestGetMultipathDevicesRetriesOnExecTimeout(t *testing.T) {
 
 func TestGetMultipathDevicesExhaustsRetriesOnExecTimeout(t *testing.T) {
 	calls := 0
-	withStubbedExec(t, func(cmd string, args []string) (string, int, error) {
+	withStubbedExec(t, func(cmd string, args []string, timeout int) (string, int, error) {
 		calls++
 		return "", 888, errExecTimeout
 	})
@@ -274,7 +279,7 @@ func TestGetMultipathDevicesExhaustsRetriesOnExecTimeout(t *testing.T) {
 
 func TestGetMultipathDevicesDoesNotRetryOnNonTimeoutError(t *testing.T) {
 	calls := 0
-	withStubbedExec(t, func(cmd string, args []string) (string, int, error) {
+	withStubbedExec(t, func(cmd string, args []string, timeout int) (string, int, error) {
 		calls++
 		return "", 1, fmt.Errorf("multipathd: command not found")
 	})
@@ -293,7 +298,7 @@ func TestGetMultipathDevicesDoesNotRetryOnNonTimeoutError(t *testing.T) {
 
 func TestGetMultipathDevicesValidJSONWithQTimeoutsNoRetry(t *testing.T) {
 	calls := 0
-	withStubbedExec(t, func(cmd string, args []string) (string, int, error) {
+	withStubbedExec(t, func(cmd string, args []string, timeout int) (string, int, error) {
 		calls++
 		return `{"maps":[{"name":"mpatha","vend":"3PARdata","paths":2,"q_timeouts":0,"total_q_time":0}]}`, 0, nil
 	})

--- a/tunelinux/multipath_test.go
+++ b/tunelinux/multipath_test.go
@@ -3,8 +3,87 @@ package tunelinux
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 )
+
+func TestReconfigureMultipathdIfConfigNotApplied(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "multipath.conf")
+	appliedHashPath := filepath.Join(tempDir, "run", "multipath-config.sha256")
+	config := []byte("defaults {\n\tfind_multipaths no\n}\n")
+	if err := os.WriteFile(configPath, config, 0600); err != nil {
+		t.Fatalf("write multipath config: %v", err)
+	}
+	reconfigureCalls := 0
+	reconfigure := func() (string, error) {
+		reconfigureCalls++
+		return "ok", nil
+	}
+
+	if err := reconfigureMultipathdIfConfigNotApplied(configPath, appliedHashPath, reconfigure); err != nil {
+		t.Fatalf("initial reconfigureMultipathdIfConfigNotApplied() error = %v, want nil", err)
+	}
+	if reconfigureCalls != 1 {
+		t.Fatalf("reconfigure called %d times without applied state, want 1", reconfigureCalls)
+	}
+
+	if err := reconfigureMultipathdIfConfigNotApplied(configPath, appliedHashPath, reconfigure); err != nil {
+		t.Fatalf("repeat reconfigureMultipathdIfConfigNotApplied() error = %v, want nil", err)
+	}
+	if reconfigureCalls != 1 {
+		t.Fatalf("reconfigure called %d times for applied content, want 1", reconfigureCalls)
+	}
+
+	if err := os.WriteFile(configPath, append(config, []byte("devices {}\n")...), 0600); err != nil {
+		t.Fatalf("update multipath config: %v", err)
+	}
+	if err := reconfigureMultipathdIfConfigNotApplied(configPath, appliedHashPath, reconfigure); err != nil {
+		t.Fatalf("changed reconfigureMultipathdIfConfigNotApplied() error = %v, want nil", err)
+	}
+	if reconfigureCalls != 2 {
+		t.Fatalf("reconfigure called %d times for changed content, want 2", reconfigureCalls)
+	}
+}
+
+func TestReconfigureMultipathdIfConfigNotAppliedRetriesAfterFailure(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "multipath.conf")
+	appliedHashPath := filepath.Join(tempDir, "run", "multipath-config.sha256")
+	if err := os.WriteFile(configPath, []byte("defaults {}\n"), 0600); err != nil {
+		t.Fatalf("write multipath config: %v", err)
+	}
+	reconfigureCalls := 0
+	reconfigure := func() (string, error) {
+		reconfigureCalls++
+		if reconfigureCalls == 1 {
+			return "", errors.New("reconfigure failed")
+		}
+		return "ok", nil
+	}
+
+	if err := reconfigureMultipathdIfConfigNotApplied(configPath, appliedHashPath, reconfigure); err == nil {
+		t.Fatal("first reconfigureMultipathdIfConfigNotApplied() error = nil, want error")
+	}
+	if err := reconfigureMultipathdIfConfigNotApplied(configPath, appliedHashPath, reconfigure); err != nil {
+		t.Fatalf("retry reconfigureMultipathdIfConfigNotApplied() error = %v, want nil", err)
+	}
+	if reconfigureCalls != 2 {
+		t.Fatalf("reconfigure called %d times after initial failure, want 2", reconfigureCalls)
+	}
+}
+
+func TestReconfigureMultipathdIfConfigNotAppliedReturnsReadError(t *testing.T) {
+	tempDir := t.TempDir()
+	err := reconfigureMultipathdIfConfigNotApplied(filepath.Join(tempDir, "missing.conf"), filepath.Join(tempDir, "state", "hash"), func() (string, error) {
+		t.Fatal("reconfigure called when config could not be read")
+		return "", nil
+	})
+	if err == nil {
+		t.Fatal("reconfigureMultipathdIfConfigNotApplied() error = nil, want read error")
+	}
+}
 
 func TestParseMultipathDevices(t *testing.T) {
 	tests := []struct {

--- a/tunelinux/multipath_test.go
+++ b/tunelinux/multipath_test.go
@@ -222,46 +222,21 @@ func TestParseMultipathDevicesValidJSONWithQTimeoutsNotTimeout(t *testing.T) {
 func withStubbedExec(t *testing.T, fn func(cmd string, args []string, timeout int) (string, int, error)) {
 	t.Helper()
 	origExec := execCommandOutput
-	origSleep := multipathTimeoutRetrySleep
 	execCommandOutput = fn
-	multipathTimeoutRetrySleep = 0
 	t.Cleanup(func() {
 		execCommandOutput = origExec
-		multipathTimeoutRetrySleep = origSleep
 	})
 }
 
 var errExecTimeout = fmt.Errorf("command multipathd killed as timeout of 60 seconds reached")
 
-func TestGetMultipathDevicesRetriesOnExecTimeout(t *testing.T) {
+func TestGetMultipathDevicesReturnsTimeoutError(t *testing.T) {
 	calls := 0
 	withStubbedExec(t, func(cmd string, args []string, timeout int) (string, int, error) {
 		calls++
 		if timeout != linux.MultipathdCommandTimeout() {
 			t.Fatalf("timeout = %d, want %d", timeout, linux.MultipathdCommandTimeout())
 		}
-		if calls < multipathTimeoutMaxTries {
-			return "", 888, errExecTimeout
-		}
-		return `{"maps":[{"name":"healthy","vend":"Nimble","paths":2}]}`, 0, nil
-	})
-
-	devices, err := GetMultipathDevices()
-	if err != nil {
-		t.Fatalf("GetMultipathDevices() error = %v, want nil", err)
-	}
-	if calls != multipathTimeoutMaxTries {
-		t.Fatalf("execCommandOutput called %d times, want %d", calls, multipathTimeoutMaxTries)
-	}
-	if len(devices) != 1 {
-		t.Fatalf("GetMultipathDevices() returned %d devices, want 1", len(devices))
-	}
-}
-
-func TestGetMultipathDevicesExhaustsRetriesOnExecTimeout(t *testing.T) {
-	calls := 0
-	withStubbedExec(t, func(cmd string, args []string, timeout int) (string, int, error) {
-		calls++
 		return "", 888, errExecTimeout
 	})
 
@@ -272,12 +247,12 @@ func TestGetMultipathDevicesExhaustsRetriesOnExecTimeout(t *testing.T) {
 	if devices != nil {
 		t.Fatalf("GetMultipathDevices() devices = %v, want nil", devices)
 	}
-	if calls != multipathTimeoutMaxTries {
-		t.Fatalf("execCommandOutput called %d times, want %d", calls, multipathTimeoutMaxTries)
+	if calls != 1 {
+		t.Fatalf("execCommandOutput called %d times, want 1", calls)
 	}
 }
 
-func TestGetMultipathDevicesDoesNotRetryOnNonTimeoutError(t *testing.T) {
+func TestGetMultipathDevicesReturnsNonTimeoutError(t *testing.T) {
 	calls := 0
 	withStubbedExec(t, func(cmd string, args []string, timeout int) (string, int, error) {
 		calls++

--- a/util/cmd.go
+++ b/util/cmd.go
@@ -19,8 +19,10 @@ package util
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -29,8 +31,25 @@ import (
 )
 
 const (
-	defaultTimeout = 60
+	defaultTimeoutSeconds = 60
+	cmdTimeoutEnvVar      = "HPE_CMD_TIMEOUT_SECONDS"
 )
+
+var defaultTimeout = loadDefaultTimeout()
+
+// loadDefaultTimeout returns the command timeout configured by cmdTimeoutEnvVar.
+// It falls back to defaultTimeoutSeconds when the variable is unset or is not a
+// positive integer.
+func loadDefaultTimeout() int {
+	if val, ok := os.LookupEnv(cmdTimeoutEnvVar); ok {
+		if timeout, err := strconv.Atoi(val); err == nil && timeout > 0 {
+			log.Infof("Using command timeout of %d seconds from %s", timeout, cmdTimeoutEnvVar)
+			return timeout
+		}
+		log.Warnf("Invalid value %q for %s (must be a positive integer), using default timeout of %d seconds", val, cmdTimeoutEnvVar, defaultTimeoutSeconds)
+	}
+	return defaultTimeoutSeconds
+}
 
 func execCommandOutputWithTimeout(cmd string, args []string, stdinArgs []string, timeout int) (string, int, error) {
 	log.Trace("execCommandOutputWithTimeout called with ", cmd, log.Scrubber(args), timeout)

--- a/util/cmd_test.go
+++ b/util/cmd_test.go
@@ -17,9 +17,40 @@ limitations under the License.
 package util
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
+
+func TestLoadDefaultTimeout(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		set   bool
+		want  int
+	}{
+		{name: "unset", want: defaultTimeoutSeconds},
+		{name: "valid", value: "120", set: true, want: 120},
+		{name: "zero", value: "0", set: true, want: defaultTimeoutSeconds},
+		{name: "negative", value: "-1", set: true, want: defaultTimeoutSeconds},
+		{name: "not an integer", value: "invalid", set: true, want: defaultTimeoutSeconds},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv(cmdTimeoutEnvVar, test.value)
+			if !test.set {
+				if err := os.Unsetenv(cmdTimeoutEnvVar); err != nil {
+					t.Fatalf("unset %s: %v", cmdTimeoutEnvVar, err)
+				}
+			}
+
+			if got := loadDefaultTimeout(); got != test.want {
+				t.Fatalf("loadDefaultTimeout() = %d, want %d", got, test.want)
+			}
+		})
+	}
+}
 
 func TestEchoExecCommandOutput(t *testing.T) {
 	out, rc, err := ExecCommandOutput("echo", []string{"Hello"})


### PR DESCRIPTION
The following changes are made through this PR

1) Make defaultTimeout env-overridable through the HPE_CMD_TIMEOUT_SECONDS environment variable.

2) Set the multipath command executor timeout to 5 seconds more than multipath ux_sock_timeout. 

3) Skip multipath reconfigure if there is no change in multipath.conf

Reference: https://jira.storage.hpecorp.net/browse/CON-4777 